### PR TITLE
TOLK-2190 : Lønnskrav (skift) skal forsvinne når tilgjengelighet tilbaketrekkes

### DIFF
--- a/force-app/main/wageClaim/classes/HOT_WageClaimHandler.cls
+++ b/force-app/main/wageClaim/classes/HOT_WageClaimHandler.cls
@@ -9,20 +9,28 @@ public without sharing class HOT_WageClaimHandler extends MyTriggers {
         }
         if (!wageClaimsWithServiceResource.isEmpty()) {
             setServiceTerritoryBasedOnServiceResource(wageClaimsWithServiceResource);
-            createShiftAndSetLookup(wageClaimsWithServiceResource.keySet());
         }
     }
     public override void onAfterInsert() {
         List<Id> wageClaimsWithParent = new List<Id>();
+        Map<HOT_WageClaim__c, Id> wageClaimsWithServiceResource = new Map<HOT_WageClaim__c, Id>();
+    
         for (HOT_WageClaim__c wageClaim : (List<HOT_WageClaim__c>) records) {
             if (wageClaim.ParentWageClaim__c != null) {
                 wageClaimsWithParent.add(wageClaim.Id);
+            } 
+            if (wageClaim.ServiceResource__c != null) {
+                // Should never be null
+                wageClaimsWithServiceResource.put(wageClaim, wageClaim.ServiceResource__c);
             }
         }
         if (wageClaimsWithParent.size() > 0) {
             setFieldsBasedOnParent(wageClaimsWithParent);
         }
-    }
+        if (!wageClaimsWithServiceResource.isEmpty()) {
+            createShiftAndSetLookup(wageClaimsWithServiceResource.keySet());
+        }
+}
     public override void onAfterUpdate(Map<Id, sObject> triggerOldMap) {
         List<HOT_WageClaim__c> retractedWageClaims = new List<HOT_WageClaim__c>();
         List<HOT_WageClaim__c> closedWageClaims = new List<HOT_WageClaim__c>();


### PR DESCRIPTION
Når frilanstolk/formidler trekker tilbake tilgjengelighet for et oppdrag skal det ikke dannes lønnskrav/skift i ressursplanleggeren.

Det har visst vært en feil hvor metoden lå i onBeforeInsert, og metoden skulle bruke Id til wc. Måtte flytte den til onAfterInsert

### **+Codecoverage spratt opp 1% med denne hehehehehe**