### PR TITLE
TOLK 2454 : Samtaler forsvinner ikke fra Ulest-listene til formidler

### DIFF
--- a/force-app/main/default/permissionsets/HOT_Tolk_Ansatt.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/HOT_Tolk_Ansatt.permissionset-meta.xml
@@ -1131,12 +1131,12 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Thread__c.CRM_Related_Object_Type__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Thread__c.CRM_Related_Object__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -1151,8 +1151,13 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Thread__c.CRM_Thread_Type__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Thread__c.CRM_Type__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -1176,6 +1181,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Thread__c.HOT_ServiceAppointment__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Thread__c.HOT_Subject__c</field>
         <readable>true</readable>
@@ -1188,6 +1198,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>Thread__c.HOT_Title__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Thread__c.HOT_WorkOrder__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>


### PR DESCRIPTION
Siden metoden sjekker på visse felt før den markerer samtalen som lest, så er disse feltene tomme i tilfellene hvor ansatte startet samtaler fordi de ikke hadde tilgang

[TOLK-2453](https://jira.adeo.no/browse/TOLK-2453)