### PR TITLE
Endring på dialoglønsingen

### DIFF
--- a/force-app/main/dialogue/classes/HOT_MessageHelper.cls
+++ b/force-app/main/dialogue/classes/HOT_MessageHelper.cls
@@ -254,12 +254,6 @@ public without sharing class HOT_MessageHelper {
                     AND ServiceAppointment__r.Status = 'Dispatched'
                     AND Status__c = 'Assigned')
                     OR (ServiceAppointment__c = :recordId
-                    AND Status__c = 'Canceled')
-                    OR (ServiceAppointment__c = :recordId
-                    AND Status__c = 'Canceled by Interpreter')
-                    OR (ServiceAppointment__c = :recordId
-                    AND Status__c = 'Cannot Complete')
-                    OR (ServiceAppointment__c = :recordId
                     AND ServiceAppointment__r.Status = 'Completed'
                     AND Status__c = 'Assigned')
             ];
@@ -306,8 +300,6 @@ public without sharing class HOT_MessageHelper {
                 WHERE
                     Id = :recordId
                     AND Status__c != 'Assigned'
-                    AND Status__c != 'Canceled'
-                    AND Status__c != 'Canceled by Interpreter'
             ];
             thread.CRM_Related_Object__c = recordId;
             thread.CRM_Thread_Type__c = 'HOT_TOLK-FORMIDLER';

--- a/force-app/main/dialogue/classes/HOT_MessageHelper.cls
+++ b/force-app/main/dialogue/classes/HOT_MessageHelper.cls
@@ -259,7 +259,7 @@ public without sharing class HOT_MessageHelper {
             ];
             if (irList.isEmpty()) {
                 //=Ansatt-tolk
-                List<HOT_InterestedResource__c> checkIfNotEmployee = [
+                List<HOT_InterestedResource__c> existingIrNoEmployeeList = [
                 SELECT
                     Id,
                     ServiceAppointment__r.Subject,
@@ -272,7 +272,7 @@ public without sharing class HOT_MessageHelper {
                     FROM AssignedResource
                     WHERE ServiceAppointmentId = :recordId
                 ];
-                for(HOT_InterestedResource__c ir : checkIfNotEmployee){
+                for(HOT_InterestedResource__c ir : existingIrNoEmployeeList){
                     if(ir.ServiceResource__c==ar.ServiceResourceId){
                         throw new AuraHandledException('no employee');
                     }

--- a/force-app/main/dialogue/classes/HOT_MessageHelper.cls
+++ b/force-app/main/dialogue/classes/HOT_MessageHelper.cls
@@ -292,22 +292,28 @@ public without sharing class HOT_MessageHelper {
         if (objectType == 'HOT_InterestedResource__c') {
             HOT_InterestedResource__c ir = [
                 SELECT
-                    Id,
-                    ServiceAppointment__r.Subject,
-                    ServiceResource__r.AccountId,
-                    ServiceAppointment__r.HOT_Request__r.Dispatcher__c
+                Id,
+                ServiceAppointment__r.Subject,
+                ServiceResource__r.AccountId,
+                ServiceAppointment__r.HOT_Request__r.Dispatcher__c,
+                ServiceAppointment__c
                 FROM HOT_InterestedResource__c
                 WHERE
-                    Id = :recordId
-                    AND Status__c != 'Assigned'
-            ];
-            thread.CRM_Related_Object__c = recordId;
-            thread.CRM_Thread_Type__c = 'HOT_TOLK-FORMIDLER';
-            thread.CRM_Account__c = ir.ServiceResource__r.AccountId;
-            thread.HOT_InterestedResource__c = recordId;
-            thread.HOT_Title__c = ir.ServiceAppointment__r.Subject;
-            thread.HOT_Dispatcher__c = ir.ServiceAppointment__r.HOT_Request__r.Dispatcher__c;
-            HOT_DatabaseOperations.insertRecords(thread);
+                Id = :recordId
+                AND Status__c != 'Assigned'
+                ];
+            List<Thread__c> checkExistingThreads = [SELECT Id, CRM_Account__c, HOT_ServiceAppointment__c FROM Thread__c WHERE CRM_Account__c =:ir.ServiceResource__r.AccountId AND HOT_ServiceAppointment__c=:ir.ServiceAppointment__c];
+            if(checkExistingThreads.size()==0){
+                thread.CRM_Related_Object__c = recordId;
+                thread.CRM_Thread_Type__c = 'HOT_TOLK-FORMIDLER';
+                thread.CRM_Account__c = ir.ServiceResource__r.AccountId;
+                thread.HOT_InterestedResource__c = recordId;
+                thread.HOT_Title__c = ir.ServiceAppointment__r.Subject;
+                thread.HOT_Dispatcher__c = ir.ServiceAppointment__r.HOT_Request__r.Dispatcher__c;
+                HOT_DatabaseOperations.insertRecords(thread);  
+            }else{
+                throw new AuraHandledException('thread exist');
+            }
         }
         if (objectType == 'HOT_WageClaim__c') {
             HOT_WageClaim__c wageClaim = [

--- a/force-app/main/dialogue/classes/HOT_MessageHelper.cls
+++ b/force-app/main/dialogue/classes/HOT_MessageHelper.cls
@@ -259,11 +259,24 @@ public without sharing class HOT_MessageHelper {
             ];
             if (irList.isEmpty()) {
                 //=Ansatt-tolk
+                List<HOT_InterestedResource__c> checkIfNotEmployee = [
+                SELECT
+                    Id,
+                    ServiceAppointment__r.Subject,
+                    ServiceResource__c,
+                    ServiceAppointment__r.HOT_Request__r.Dispatcher__c
+                FROM HOT_InterestedResource__c WHERE ServiceAppointment__c = :recordId];
+
                 AssignedResource ar = [
                     SELECT Id, ServiceAppointmentId, ServiceResourceId
                     FROM AssignedResource
                     WHERE ServiceAppointmentId = :recordId
                 ];
+                for(HOT_InterestedResource__c ir : checkIfNotEmployee){
+                    if(ir.ServiceResource__c==ar.ServiceResourceId){
+                        throw new AuraHandledException('no employee');
+                    }
+                }
                 //ServiceResource sr=[SELECT Id, AccountId FROM ServiceResource WHERE Id=:ar.ServiceResourceId];
                 ServiceAppointment sa = [
                     SELECT Id, Subject, HOT_Request__r.Dispatcher__c

--- a/force-app/main/dialogue/classes/HOT_ThreadHandler.cls
+++ b/force-app/main/dialogue/classes/HOT_ThreadHandler.cls
@@ -202,7 +202,7 @@ public without sharing class HOT_ThreadHandler extends MyTriggers {
         for (Thread__c thread : threads) {
             threadRelatedObjectId.add(thread.CRM_Related_Object__c);
         }
-
+        
         List<ServiceAppointment> saList = [
             SELECT Id, HOT_ServiceResource__r.RelatedRecordId
             FROM ServiceAppointment
@@ -213,32 +213,11 @@ public without sharing class HOT_ThreadHandler extends MyTriggers {
             FROM HOT_InterestedResource__c
             WHERE Id IN :threadRelatedObjectId
         ];
-         List<HOT_InterestedResource__c> irListWhenNoSr = [
-                SELECT
-                    Id,
-                    Status__c,
-                    ServiceAppointment__c,
-                    ServiceResource__r.RelatedRecordId
-                FROM HOT_InterestedResource__c
-                WHERE 
-                ServiceAppointment__c IN :threadRelatedObjectId
-                    AND (
-                    Status__c = 'Canceled' OR
-                    Status__c = 'Canceled by Interpreter' OR
-                    Status__c = 'Cannot Complete')
-            ];
         if (saList.size() > 0) {
             for (Thread__c thread : threads) {
                 for (ServiceAppointment sa : saList) {
                     if (thread.CRM_Related_Object__c == sa.Id && sa.HOT_ServiceResource__r.RelatedRecordId != null) {
                         thread.HOT_ParticipantIds__c = sa.HOT_ServiceResource__r.RelatedRecordId;
-                    }
-                    else{
-                        for (HOT_InterestedResource__c ir : irListWhenNoSr) {
-                            if (thread.CRM_Related_Object__c == ir.ServiceAppointment__c) {
-                                thread.HOT_ParticipantIds__c = ir.ServiceResource__r.RelatedRecordId;
-                            }
-                        }
                     }
                 }
             }

--- a/force-app/main/dialogue/internal-components/lwc/hot_messagingMessageComponent/hot_messagingMessageComponent.html
+++ b/force-app/main/dialogue/internal-components/lwc/hot_messagingMessageComponent/hot_messagingMessageComponent.html
@@ -4,7 +4,10 @@
             <span class="slds-assistive-text">Advarsel</span>
             <lightning-icon icon-name="utility:warning" size="x-small" class="slds-m-right--x-small" variant="inverse">
             </lightning-icon>
-            <span>Du må tildele en interessert ressurs dette oppdraget før du kan starte samtale.</span>
+            <span
+                >Du må tildele en interessert ressurs dette oppdraget før du kan starte samtale. Er oppdraget avlyst
+                start samtale på interessert ressurs.</span
+            >
         </div>
     </template>
     <template if:true={interestedResourceIsAssigned}>


### PR DESCRIPTION
Ettersom vi for en tid siden endret slik at når tolken avlyste og fikk status avlyst av tolk, og for at vi skal kunne sette participant feltet når det skal startes en samtale med tolk etter at det er avlyst på en eller anne måte, må vi endre slik at det kan kun startes samtale fra SA når tolken er tildelt/reservert. Ellers må det gjøres via IR.

Har måtte endre litt funksjonalitet. Om tolken er tildelt oppdraget og det på noen måte avlyses;

- Om det finnes samtale fra før det avlyses må får man beskjed om å fortsette samtalen på SA. (den blir som vanlig overført til IR når ny tolk tildeles)

- Om det lages en samtale etter at det er avlyst må det lages på IR. 