### PR TITLE
Update HOT_Tolk_Ansatt.permissionset-meta.xml

### DIFF
--- a/force-app/main/default/permissionsets/HOT_Tolk_Ansatt.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/HOT_Tolk_Ansatt.permissionset-meta.xml
@@ -281,7 +281,7 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>true</editable>
+        <editable>false</editable>
         <field>HOT_Request__c.EconomicProvider__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -293,6 +293,11 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>HOT_Request__c.ExternalRequestStatus__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>HOT_Request__c.HOT_PersonContactId__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>


### PR DESCRIPTION
- Maglet en tilgang på feltet HOT_PersonContactId__c som første til at flow'wn feilet.
- Feltet EconomicProvider__c har tidligere blitt endret til et formelfelt, så da er det ikke lenger mulig å ha edit