### PR TITLE
Tolk 2629 heldagsfravær

### DIFF
--- a/force-app/main/freelanceCalendar/lwc/hot_calendar/hot_calendar.js
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar/hot_calendar.js
@@ -119,7 +119,15 @@ export default class LibsFullCalendar extends NavigationMixin(LightningElement) 
                 absence: {
                     text: 'Nytt fravær',
                     click: () => {
-                        this.openAbsenceModal();
+                        if (this.calendar?.view.type == 'timeGridDay') {
+                            const millisecondsPerHour = 60 * 60 * 1000;
+                            const viewedDate = this.calendar.view.activeStart;
+                            const suggestedStartTime = new Date(viewedDate.getTime() + 12 * millisecondsPerHour);
+                            const suggestEndTime = new Date(suggestedStartTime.getTime() + millisecondsPerHour);
+                            this.openAbsenceModal(null, suggestedStartTime, suggestEndTime);
+                        } else {
+                            this.openAbsenceModal();
+                        }
                     }
                 }
             },
@@ -280,8 +288,8 @@ export default class LibsFullCalendar extends NavigationMixin(LightningElement) 
         this.isLoading = false;
     }
 
-    async openAbsenceModal(event) {
-        const result = await Hot_Calendar_Absence_Modal.open({ event: event });
+    async openAbsenceModal(event, initialAbsenceStart, initialAbsenceEnd) {
+        const result = await Hot_Calendar_Absence_Modal.open({ event, initialAbsenceEnd, initialAbsenceStart });
         if (result) {
             await this.refreshCalendar(false);
             this.updatePseudoEventsDisplay(this.calendar.view);

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.html
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.html
@@ -5,75 +5,46 @@
                 <lightning-spinner alternative-text="Loading" size="large"></lightning-spinner>
             </div>
         </template>
-        <template lwc:if={isEdit}>
-            <lightning-modal-header label="Endre/Slett fravær"></lightning-modal-header>
-            <lightning-modal-body>
-                <lightning-radio-group
-                    name="radioGroup"
-                    lwc:ref="absenceTypeRadioGroup"
-                    label="Type fravær"
-                    options={options}
-                    value={absenceType}
-                    type="radio"
-                >
-                </lightning-radio-group>
-                <lightning-input
-                    type="datetime"
-                    name="input1"
-                    lwc:ref="absenceStartDateTimeInput"
-                    label="Legg inn ny start dato/tid"
-                    value={absenceStart}
-                ></lightning-input>
-                <lightning-input
-                    type="datetime"
-                    name="input2"
-                    lwc:ref="absenceEndDateTimeInput"
-                    label="Legg inn ny slutt dato/tid"
-                    value={absenceEnd}
-                ></lightning-input>
-            </lightning-modal-body>
-            <lightning-modal-footer>
-                <div class="button-container">
+        <lightning-modal-header label={headerText}></lightning-modal-header>
+        <lightning-modal-body>
+            <lightning-radio-group
+                name="radioGroup"
+                lwc:ref="absenceTypeRadioGroup"
+                label="Type fravær"
+                options={options}
+                value={absenceType}
+                type="radio"
+            >
+            </lightning-radio-group>
+            <lightning-input
+                type="datetime"
+                name="input1"
+                lwc:ref="absenceStartDateTimeInput"
+                label={startTimeInputLabel}
+                value={absenceStart}
+            ></lightning-input>
+            <lightning-input
+                type="datetime"
+                name="input2"
+                lwc:ref="absenceEndDateTimeInput"
+                label={endTimeInputLabel}
+                value={absenceEnd}
+            ></lightning-input>
+        </lightning-modal-body>
+        <lightning-modal-footer>
+            <div class="button-container">
+                <template lwc:if={isEdit}>
                     <button
                         class="slds-button slds-button_destructive cancel-button custom-button"
                         onclick={handleDeleteAbsence}
                     >
                         Slett
                     </button>
-                    <button class="slds-button slds-button_brand custom-button" onclick={handleOkay}>Endre</button>
-                </div>
-            </lightning-modal-footer>
-        </template>
-        <template lwc:else>
-            <lightning-modal-header label="Registrer nytt fravær"></lightning-modal-header>
-            <lightning-modal-body>
-                <lightning-radio-group
-                    name="radioGroup"
-                    lwc:ref="absenceTypeRadioGroup"
-                    label="Type fravær"
-                    options={options}
-                    value={value}
-                    type="radio"
-                >
-                </lightning-radio-group>
-                <lightning-input
-                    type="datetime"
-                    name="input1"
-                    lwc:ref="absenceStartDateTimeInput"
-                    label="Legg inn start dato/tid"
-                    value={absenceStart}
-                ></lightning-input>
-                <lightning-input
-                    type="datetime"
-                    name="input2"
-                    lwc:ref="absenceEndDateTimeInput"
-                    label="Legg inn slutt dato/tid"
-                    value={absenceEnd}
-                ></lightning-input>
-            </lightning-modal-body>
-            <lightning-modal-footer>
-                <lightning-button variant="brand" label="Registrer" onclick={handleOkay}></lightning-button>
-            </lightning-modal-footer>
-        </template>
+                </template>
+                <button class="slds-button slds-button_brand custom-button" onclick={handleOkay}>
+                    {registerButtonText}
+                </button>
+            </div>
+        </lightning-modal-footer>
     </div>
 </template>

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.html
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.html
@@ -16,20 +16,30 @@
                 type="radio"
             >
             </lightning-radio-group>
-            <lightning-input
-                type="datetime"
-                name="input1"
-                lwc:ref="absenceStartDateTimeInput"
-                label={startTimeInputLabel}
-                value={absenceStart}
-            ></lightning-input>
-            <lightning-input
-                type="datetime"
-                name="input2"
-                lwc:ref="absenceEndDateTimeInput"
-                label={endTimeInputLabel}
-                value={absenceEnd}
-            ></lightning-input>
+            <div class="slds-var-m-top_medium">
+                <lightning-input
+                    type="checkbox"
+                    label="Heldags"
+                    value={isAllDayAbsence}
+                    onchange={handleAllDayEventSet}
+                ></lightning-input>
+                <lightning-input
+                    type={timeFormat}
+                    name="input1"
+                    lwc:ref="absenceStartDateTimeInput"
+                    label={startTimeInputLabel}
+                    value={initialAbsenceStart}
+                    onchange={handleDateStartChange}
+                ></lightning-input>
+                <lightning-input
+                    type={timeFormat}
+                    name="input2"
+                    lwc:ref="absenceEndDateTimeInput"
+                    label={endTimeInputLabel}
+                    value={initialAbsenceEnd}
+                    onchange={handleDateEndChange}
+                ></lightning-input>
+            </div>
         </lightning-modal-body>
         <lightning-modal-footer>
             <div class="button-container">

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
@@ -98,7 +98,7 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
 
         const startInput = this.refs.absenceStartDateTimeInput;
         startInput.setCustomValidity(
-            startTime > endTime && this.endHasBeenSet ? 'Sluttid må komme etter starttid' : ''
+            startTime >= endTime && this.endHasBeenSet ? 'Sluttid må komme etter starttid' : ''
         );
         startInput.reportValidity();
         this.initialAbsenceStart = event.detail.value;
@@ -108,7 +108,7 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
         const startInput = this.refs.absenceStartDateTimeInput;
         const startTime = new Date(startInput.value);
         const newEndDate = new Date(event.detail.value);
-        startInput.setCustomValidity(startTime > newEndDate ? 'Sluttid må komme etter starttid' : '');
+        startInput.setCustomValidity(startTime >= newEndDate ? 'Sluttid må komme etter starttid' : '');
         startInput.reportValidity();
         this.endHasBeenSet = true;
         this.initialAbsenceEnd = event.detail.value;
@@ -138,8 +138,8 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
         }
 
         const absenceStartElement = this.refs.absenceStartDateTimeInput;
-        if (absenceEndDateTime < absenceStartDateTime) {
-            absenceStartElement.setCustomValidity('Starttid kan ikke komme etter sluttid');
+        if (absenceEndDateTime <= absenceStartDateTime) {
+            absenceStartElement.setCustomValidity('Sluttid må komme etter starttid');
             absenceStartElement.reportValidity();
             validInputs = false;
         } else {

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
@@ -11,9 +11,11 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
     @api event;
     isEdit;
     absenceType;
-    absenceStart;
-    absenceEnd;
+    initialAbsenceStart;
+    initialAbsenceEnd;
     value = '';
+    timeFormat = 'datetime';
+    isAllDayAbsence = false;
     isLoading = false;
     headerText;
     startTimeInputLabel;
@@ -28,30 +30,30 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
         ];
     }
 
+    getNorwegianAbsenceType(absenceType) {
+        switch (absenceType) {
+            case 'Ferie':
+                return 'Vacation';
+            case 'Sykdom':
+                return 'Medical';
+            case 'Annet':
+                return 'Other';
+            default:
+                return 'Other';
+        }
+    }
+
     connectedCallback() {
         if (this.event && this.event.extendedProps.recordId) {
             this.isEdit = true;
-            switch (this.event.extendedProps.description) {
-                case 'Ferie':
-                    this.absenceType = 'Vacation';
-                    break;
-                case 'Sykdom':
-                    this.absenceType = 'Medical';
-                    break;
-                case 'Annet':
-                    this.absenceType = 'Other';
-                    break;
-                default:
-                    this.absenceType = 'Other';
-                    break;
-            }
-            this.absenceStart = this.formatLocalDateTime(this.event.start);
-            this.absenceEnd = this.formatLocalDateTime(this.event.end);
+            this.absenceType = this.getNorwegianAbsenceType(this.event.extendedProps.description);
+            this.initialAbsenceStart = this.formatLocalDateTime(this.event.start);
+            this.initialAbsenceEnd = this.formatLocalDateTime(this.event.end);
         } else {
             const now = new Date();
-            const startTime = new Date(Date.now() + (60 - now.getMinutes()) * 60000);
-            this.absenceStart = this.formatLocalDateTime(startTime);
-            this.absenceEnd = this.formatLocalDateTime(new Date(startTime.getTime() + 86400000));
+            const startTime = new Date(now.getTime() + (60 - now.getMinutes()) * 60000);
+            this.initialAbsenceStart = this.formatLocalDateTime(startTime);
+            this.initialAbsenceEnd = this.formatLocalDateTime(new Date(startTime.getTime() + 86400000));
         }
 
         this.headerText = this.isEdit ? 'Endre/Slett fravær' : 'Registrer nytt fravær';
@@ -62,6 +64,47 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
 
     validateAbsenceType(absenceType) {
         return ['Vacation', 'Other', 'Medical'].includes(absenceType);
+    }
+
+    handleAllDayEventSet(event) {
+        this.isAllDayAbsence = event.detail.checked;
+        this.timeFormat = this.isAllDayAbsence ? 'date' : 'datetime';
+        const startTime = this.refs.absenceStartDateTimeInput.value;
+        const endTime = this.refs.absenceEndDateTimeInput.value;
+        if (this.isAllDayAbsence) {
+            this.initialAbsenceStart = this.formatLocalDateTime(new Date(startTime), '00', '00');
+            this.initialAbsenceEnd = this.formatLocalDateTime(new Date(endTime), '23', '59');
+        } else {
+            const hours = new Date().getHours();
+            const hoursString = (hours < 10 ? '0' : '') + hours.toString();
+            this.initialAbsenceStart = this.formatLocalDateTime(new Date(startTime), hoursString, '00');
+            this.initialAbsenceEnd = this.formatLocalDateTime(new Date(endTime), hoursString, '00');
+        }
+    }
+
+    handleDateStartChange(event) {
+        const startTime = new Date(event.detail.value);
+        const endTime = new Date(this.refs.absenceEndDateTimeInput.value);
+        if (startTime > endTime && !this.endHasBeenSet) {
+            this.initialAbsenceEnd = event.detail.value;
+        }
+
+        const startInput = this.refs.absenceStartDateTimeInput;
+        startInput.setCustomValidity(
+            startTime > endTime && this.endHasBeenSet ? 'Sluttid må komme etter starttid' : ''
+        );
+        startInput.reportValidity();
+        this.initialAbsenceStart = event.detail.value;
+    }
+
+    handleDateEndChange(event) {
+        const startInput = this.refs.absenceStartDateTimeInput;
+        const startTime = new Date(startInput.value);
+        const newEndDate = new Date(event.detail.value);
+        startInput.setCustomValidity(startTime > newEndDate ? 'Sluttid må komme etter starttid' : '');
+        startInput.reportValidity();
+        this.endHasBeenSet = true;
+        this.initialAbsenceEnd = event.detail.value;
     }
 
     async handleOkay() {
@@ -80,8 +123,13 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
         }
 
         // Fetch input field values
-        const absenceStartDateTime = this.refs.absenceStartDateTimeInput.value;
-        const absenceEndDateTime = this.refs.absenceEndDateTimeInput.value;
+        let absenceStartDateTime = this.refs.absenceStartDateTimeInput.value;
+        let absenceEndDateTime = this.refs.absenceEndDateTimeInput.value;
+        if (this.isAllDayAbsence) {
+            absenceStartDateTime = this.formatLocalDateTime(new Date(absenceStartDateTime), '00', '00');
+            absenceEndDateTime = this.formatLocalDateTime(new Date(absenceEndDateTime), '23', '59');
+        }
+
         const absenceStartElement = this.refs.absenceStartDateTimeInput;
         if (absenceEndDateTime < absenceStartDateTime) {
             absenceStartElement.setCustomValidity('Starttid kan ikke komme etter sluttid');
@@ -95,12 +143,13 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
         if (!validInputs) {
             return;
         }
+
         let result;
         try {
             result = await getConflictsForTimePeriod({
                 startTimeInMilliseconds: new Date(absenceStartDateTime).getTime(),
                 endTimeInMilliseconds: new Date(absenceEndDateTime).getTime(),
-                checkWholeDayForConflicts: false
+                checkWholeDayForConflicts: this.isAllDayAbsence
             });
         } catch {
             const event = new ShowToastEvent({
@@ -125,10 +174,9 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
                     absenceType: absenceType,
                     startTimeInMilliseconds: new Date(absenceStartDateTime).getTime(),
                     endTimeInMilliseconds: new Date(absenceEndDateTime).getTime(),
-                    isAllDayAbsence: false
+                    isAllDayAbsence: this.isAllDayAbsence
                 });
             } catch (error) {
-                console.error(error);
                 const event = new ShowToastEvent({
                     title: 'Kunne ikke legge til fravær',
                     message: 'Det oppstod en feil, prøv igjen senere',
@@ -137,7 +185,6 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
                 this.dispatchEvent(event);
             }
             if (this.isEdit) {
-                console.log('nå er vi edit');
                 try {
                     await deleteAbsence({ recordId: this.event.extendedProps.recordId });
                     const event = new ShowToastEvent({

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
@@ -87,8 +87,8 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
     handleDateStartChange(event) {
         const startTime = new Date(event.detail.value);
         const endTime = new Date(this.refs.absenceEndDateTimeInput.value);
-        if (startTime > endTime && !this.endHasBeenSet) {
-            this.initialAbsenceEnd = event.detail.value;
+        if (!this.endHasBeenSet) {
+            this.initialAbsenceEnd = this.formatLocalDateTime(new Date(startTime.getTime() + 60 * 60 * 1000 * 24));
         }
 
         const startInput = this.refs.absenceStartDateTimeInput;

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
@@ -30,23 +30,28 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
         ];
     }
 
-    getNorwegianAbsenceType(absenceType) {
-        switch (absenceType) {
-            case 'Ferie':
-                return 'Vacation';
-            case 'Sykdom':
-                return 'Medical';
-            case 'Annet':
-                return 'Other';
-            default:
-                return 'Other';
+    getEnglishAbsenceType(absenceType) {
+        for (const pair of this.options) {
+            if (absenceType === pair.label) {
+                return pair.value;
+            }
         }
+        return 'Other';
+    }
+
+    getNorwegianAbsenceType(absenceType) {
+        for (const pair of this.options) {
+            if (absenceType === pair.value) {
+                return pair.label;
+            }
+        }
+        return 'Annet';
     }
 
     connectedCallback() {
         if (this.event && this.event.extendedProps.recordId) {
             this.isEdit = true;
-            this.absenceType = this.getNorwegianAbsenceType(this.event.extendedProps.description);
+            this.absenceType = this.getEnglishAbsenceType(this.event.extendedProps.description);
             this.initialAbsenceStart = this.formatLocalDateTime(this.event.start);
             this.initialAbsenceEnd = this.formatLocalDateTime(this.event.end);
         } else {

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
@@ -192,12 +192,12 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
     }
 
     // Hjelper metode for å få dato i riktig tidsone for dateTime input felt
-    formatLocalDateTime(date) {
+    formatLocalDateTime(date, hoursOverride, minutesOverride) {
         const year = date.getFullYear();
         const month = ('0' + (date.getMonth() + 1)).slice(-2); // Måneder er 0 indeksiert
         const day = ('0' + date.getDate()).slice(-2);
-        const hours = ('0' + date.getHours()).slice(-2);
-        const minutes = ('0' + date.getMinutes()).slice(-2);
+        const hours = hoursOverride !== undefined ? hoursOverride : ('0' + date.getHours()).slice(-2);
+        const minutes = minutesOverride !== undefined ? minutesOverride : ('0' + date.getMinutes()).slice(-2);
 
         return `${year}-${month}-${day}T${hours}:${minutes}`;
     }

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
@@ -99,7 +99,8 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
         try {
             result = await getConflictsForTimePeriod({
                 startTimeInMilliseconds: new Date(absenceStartDateTime).getTime(),
-                endTimeInMilliseconds: new Date(absenceEndDateTime).getTime()
+                endTimeInMilliseconds: new Date(absenceEndDateTime).getTime(),
+                checkWholeDayForConflicts: false
             });
         } catch {
             const event = new ShowToastEvent({
@@ -123,7 +124,8 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
                 await createAbsenceAndResolveConflicts({
                     absenceType: absenceType,
                     startTimeInMilliseconds: new Date(absenceStartDateTime).getTime(),
-                    endTimeInMilliseconds: new Date(absenceEndDateTime).getTime()
+                    endTimeInMilliseconds: new Date(absenceEndDateTime).getTime(),
+                    isAllDayAbsence: false
                 });
             } catch (error) {
                 console.error(error);

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
@@ -15,6 +15,10 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
     absenceEnd;
     value = '';
     isLoading = false;
+    headerText;
+    startTimeInputLabel;
+    endTImeInputLabel;
+    registerButtonText;
 
     get options() {
         return [
@@ -49,6 +53,11 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
             this.absenceStart = this.formatLocalDateTime(startTime);
             this.absenceEnd = this.formatLocalDateTime(new Date(startTime.getTime() + 86400000));
         }
+
+        this.headerText = this.isEdit ? 'Endre/Slett fravær' : 'Registrer nytt fravær';
+        this.startTimeInputLabel = `Legg inn${this.isEdit ? ' ny' : ''} startdato/tid`;
+        this.endTimeInputLabel = `Legg inn${this.isEdit ? ' ny' : ''} sluttdato/tid`;
+        this.registerButtonText = this.isEdit ? 'Endre' : 'Registrer';
     }
 
     validateAbsenceType(absenceType) {

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
@@ -163,7 +163,7 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
 
         const confirmation = await ConfimationModal.open({
             content: result,
-            absenceType: absenceType,
+            absenceType: this.getNorwegianAbsenceType(absenceType),
             absenceStartDateTime: absenceStartDateTime,
             absenceEndDateTime: absenceEndDateTime
         });

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal/hot_calendar_absence_modal.js
@@ -11,8 +11,8 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
     @api event;
     isEdit;
     absenceType;
-    initialAbsenceStart;
-    initialAbsenceEnd;
+    @api initialAbsenceStart;
+    @api initialAbsenceEnd;
     value = '';
     timeFormat = 'datetime';
     isAllDayAbsence = false;
@@ -52,8 +52,10 @@ export default class Hot_Calendar_Absence_Modal extends LightningModal {
         } else {
             const now = new Date();
             const startTime = new Date(now.getTime() + (60 - now.getMinutes()) * 60000);
-            this.initialAbsenceStart = this.formatLocalDateTime(startTime);
-            this.initialAbsenceEnd = this.formatLocalDateTime(new Date(startTime.getTime() + 86400000));
+            this.initialAbsenceStart = this.formatLocalDateTime(this.initialAbsenceStart ?? startTime);
+            this.initialAbsenceEnd = this.formatLocalDateTime(
+                this.initialAbsenceEnd ?? new Date(startTime.getTime() + 60 * 60000)
+            );
         }
 
         this.headerText = this.isEdit ? 'Endre/Slett fravær' : 'Registrer nytt fravær';

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal_confirmation/hot_calendar_absence_modal_confirmation.html
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_absence_modal_confirmation/hot_calendar_absence_modal_confirmation.html
@@ -13,9 +13,9 @@
             <!-- Display Conflicts Message -->
             <div class="slds-p-around_medium">
                 <p>
-                    Dersom du legger til fravær vil følgende oppdrag avlyses. Ved ledig på lønn vil du bli satt
-                    utilgjengelig.
+                    Ved bekreftelse vil Oppdrag i listen under få status "Avlyst av tolk", og du blir tatt av oppdraget.
                 </p>
+                <p>Ved Ledig på lønn bekrefter du å tilbaketrekke tilgjengeligheten, og mister retten til lønn.</p>
             </div>
 
             <!-- Display Conflicts -->

--- a/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceController.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceController.cls
@@ -88,7 +88,6 @@ public with sharing class HOT_FreelanceAbsenceController {
         Date splitDate = startTime.addDays(14).date();
         Datetime splitDatetime = Datetime.newInstance(splitDate.year(), splitDate.month(), splitDate.day());
         Datetime previous = startTime;
-        System.debug('Andre ' + previous + ' ' + endTime);
         while (previous < endTime) {
             Datetime chunkEndTime = splitDatetime < endTime ? splitDatetime : endTime;
             events.add(createAbsenceEvent(absence.Id, previous, chunkEndTime, absenceType));

--- a/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceController.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceController.cls
@@ -79,11 +79,43 @@ public with sharing class HOT_FreelanceAbsenceController {
             prepareAndThrowAuraException(ERROR_FAILED_TO_CREATE_ABSENCE);
         }
 
+        // Maks Event lengde er 14 dager, fordi Salesforce
+
+        Event[] events = new List<Event>();
+        Date splitDate = startTime.addDays(14).date();
+        Datetime splitDatetime = Datetime.newInstance(splitDate.year(), splitDate.month(), splitDate.day());
+        Datetime previous = startTime;
+        while (previous < endTime) {
+            Datetime chunkEndTime = splitDatetime < endTime ? splitDatetime : endTime;
+            events.add(createAbsenceEvent(absence.Id, previous, chunkEndTime, absenceType));
+            previous = splitDatetime;
+            splitDatetime = splitDatetime.addDays(14);
+        }
+
+        try {
+            insert events;
+        } catch (Exception e) {
+            logException(e, absence);
+            prepareAndThrowAuraException(ERROR_FAILED_TO_CREATE_ABSENCE);
+        }
+
+        absence.HOT_EventId__c = events[0].Id;
+
+        try {
+            update absence;
+        } catch (Exception e) {
+            logException(e, absence);
+            prepareAndThrowAuraException(ERROR_FAILED_TO_CREATE_ABSENCE);
+        }
+
+        return absence.Id;
+    }
+
+    private static Event createAbsenceEvent(Id absenceId, Datetime startTime, Datetime endTime, String absenceType) {
         Event event = new Event();
-        event.WhatId = absence.Id;
-        event.isAllDayEvent = isAllDayAbsence;
-        event.StartDateTime = absence.Start;
-        event.EndDateTime = absence.End;
+        event.WhatId = absenceId;
+        event.StartDateTime = startTime;
+        event.EndDateTime = endTime;
         switch on absenceType {
             when 'Other' {
                 event.Description = 'Annet';
@@ -97,24 +129,7 @@ public with sharing class HOT_FreelanceAbsenceController {
         }
         event.Subject = 'Fravær';
         event.ShowAs = 'Busy';
-
-        try {
-            insert event;
-        } catch (Exception e) {
-            logException(e, absence);
-            prepareAndThrowAuraException(ERROR_FAILED_TO_CREATE_ABSENCE);
-        }
-
-        absence.HOT_EventId__c = event.Id;
-
-        try {
-            update absence;
-        } catch (Exception e) {
-            logException(e, absence);
-            prepareAndThrowAuraException(ERROR_FAILED_TO_CREATE_ABSENCE);
-        }
-
-        return absence.Id;
+        return event;
     }
 
     @AuraEnabled(cacheable=false)

--- a/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceController.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceController.cls
@@ -45,7 +45,7 @@ public with sharing class HOT_FreelanceAbsenceController {
             prepareAndThrowAuraException(ERROR_INVALID_ABSENCE_TYPE);
         }
 
-        if (startTimeInMilliseconds > endTimeInMilliseconds) {
+        if (startTimeInMilliseconds >= endTimeInMilliseconds) {
             prepareAndThrowAuraException(ERROR_INVALID_START_AND_END_TIME);
         }
 
@@ -57,7 +57,7 @@ public with sharing class HOT_FreelanceAbsenceController {
             Date endDate = endTime.date();
             startTime = Datetime.newInstance(startDate.year(), startDate.month(), startDate.day());
             endTime = Datetime.newInstance(endDate.year(), endDate.month(), endDate.day());
-            if (endTime != Datetime.newInstance(endTimeInMilliseconds)) {
+            if (endTime != Datetime.newInstance(endTimeInMilliseconds) || startTime == endTime) {
                 // om tid ikke er start på dagen, flytt end time til slutt på dagen.
                 endTime = endTime.addDays(1);
             }
@@ -88,6 +88,7 @@ public with sharing class HOT_FreelanceAbsenceController {
         Date splitDate = startTime.addDays(14).date();
         Datetime splitDatetime = Datetime.newInstance(splitDate.year(), splitDate.month(), splitDate.day());
         Datetime previous = startTime;
+        System.debug('Andre ' + previous + ' ' + endTime);
         while (previous < endTime) {
             Datetime chunkEndTime = splitDatetime < endTime ? splitDatetime : endTime;
             events.add(createAbsenceEvent(absence.Id, previous, chunkEndTime, absenceType));

--- a/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceController.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceController.cls
@@ -57,7 +57,10 @@ public with sharing class HOT_FreelanceAbsenceController {
             Date endDate = endTime.date();
             startTime = Datetime.newInstance(startDate.year(), startDate.month(), startDate.day());
             endTime = Datetime.newInstance(endDate.year(), endDate.month(), endDate.day());
-            endTime = endTime.addDays(1);
+            if (endTime != Datetime.newInstance(endTimeInMilliseconds)) {
+                // om tid ikke er start på dagen, flytt end time til slutt på dagen.
+                endTime = endTime.addDays(1);
+            }
         }
 
         ResourceAbsence absence = new ResourceAbsence();

--- a/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceController.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceController.cls
@@ -35,10 +35,11 @@ public with sharing class HOT_FreelanceAbsenceController {
     }
 
     @AuraEnabled
-    public static void createAbsenceAndResolveConflicts(
+    public static Id createAbsenceAndResolveConflicts(
         Long startTimeInMilliseconds,
         Long endTimeInMilliseconds,
-        String absenceType
+        String absenceType,
+        Boolean isAllDayAbsence
     ) {
         if (absenceType != 'Other' && absenceType != 'Medical' && absenceType != 'Vacation') {
             prepareAndThrowAuraException(ERROR_INVALID_ABSENCE_TYPE);
@@ -48,9 +49,20 @@ public with sharing class HOT_FreelanceAbsenceController {
             prepareAndThrowAuraException(ERROR_INVALID_START_AND_END_TIME);
         }
 
+        Datetime startTime = Datetime.newInstance(startTimeInMilliseconds);
+        Datetime endTime = Datetime.newInstance(endTimeInMilliseconds);
+
+        if (isAllDayAbsence) {
+            Date startDate = startTime.date();
+            Date endDate = endTime.date();
+            startTime = Datetime.newInstance(startDate.year(), startDate.month(), startDate.day());
+            endTime = Datetime.newInstance(endDate.year(), endDate.month(), endDate.day());
+            endTime = endTime.addDays(1);
+        }
+
         ResourceAbsence absence = new ResourceAbsence();
-        absence.Start = Datetime.newInstance(startTimeInMilliseconds);
-        absence.End = Datetime.newInstance(endTimeInMilliseconds);
+        absence.Start = startTime;
+        absence.End = endTime;
         absence.ResourceId = getUserServiceResourceId();
         absence.Type = absenceType;
 
@@ -69,6 +81,7 @@ public with sharing class HOT_FreelanceAbsenceController {
 
         Event event = new Event();
         event.WhatId = absence.Id;
+        event.isAllDayEvent = isAllDayAbsence;
         event.StartDateTime = absence.Start;
         event.EndDateTime = absence.End;
         switch on absenceType {
@@ -100,12 +113,15 @@ public with sharing class HOT_FreelanceAbsenceController {
             logException(e, absence);
             prepareAndThrowAuraException(ERROR_FAILED_TO_CREATE_ABSENCE);
         }
+
+        return absence.Id;
     }
 
     @AuraEnabled(cacheable=false)
     public static List<ConflictingRecord> getConflictsForTimePeriod(
         Long startTimeInMilliseconds,
-        Long endTimeInMilliseconds
+        Long endTimeInMilliseconds,
+        Boolean checkWholeDayForConflicts
     ) {
         if (startTimeInMilliseconds > endTimeInMilliseconds) {
             prepareAndThrowAuraException(ERROR_INVALID_START_AND_END_TIME);
@@ -113,6 +129,14 @@ public with sharing class HOT_FreelanceAbsenceController {
 
         Datetime startTime = Datetime.newInstance(startTimeInMilliseconds);
         Datetime endTime = Datetime.newInstance(endTimeInMilliseconds);
+
+        if (checkWholeDayForConflicts) {
+            Date startDate = startTime.date();
+            Date endDate = endTime.date();
+            startTime = Datetime.newInstance(startDate.year(), startDate.month(), startDate.day());
+            endTime = Datetime.newInstance(endDate.year(), endDate.month(), endDate.day());
+            endTime = endTime.addDays(1);
+        }
 
         List<ServiceAppointment> conflictingAppointments = getConflictingServiceAppointments(startTime, endTime);
 

--- a/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceControllerTest.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceControllerTest.cls
@@ -204,8 +204,6 @@ private class HOT_FreelanceAbsenceControllerTest {
             true
         );
 
-        System.debug('Andre ' + conflictsBeforeResolution);
-
         Test.startTest();
         absenceId = HOT_FreelanceAbsenceController.createAbsenceAndResolveConflicts(
             absenceStart.getTime(),
@@ -215,7 +213,6 @@ private class HOT_FreelanceAbsenceControllerTest {
         );
 
         Test.stopTest();
-        System.debug('Andre' + absenceId);
 
         HOT_FreelanceAbsenceController.ConflictingRecord[] conflictsAfterResolution = HOT_FreelanceAbsenceController.getConflictsForTimePeriod(
             absenceStart.getTime(),
@@ -223,16 +220,12 @@ private class HOT_FreelanceAbsenceControllerTest {
             true
         );
 
-        System.debug('Andre' + conflictsAfterResolution);
-
         ResourceAbsence absence = [
             SELECT Id
             FROM ResourceAbsence
             WHERE Id = :absenceId
             LIMIT 1
         ];
-
-        System.debug('Andre' + absence);
 
         Event[] relatedEvents = [
             SELECT Id

--- a/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceControllerTest.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceControllerTest.cls
@@ -195,7 +195,7 @@ private class HOT_FreelanceAbsenceControllerTest {
     static void createAbsenceAndResolveConflictsWholeDayTest() {
         Datetime absenceStart = Datetime.now().addHours(ABSENCE_START_TIME_OFFSET_IN_HOURS).addMinutes(1);
         absenceStart = Datetime.newInstance(absenceStart.year(), absenceStart.month(), absenceStart.day());
-        Datetime absenceEnd = absenceStart;
+        Datetime absenceEnd = absenceStart.addMinutes(1);
         Id absenceId = null;
 
         HOT_FreelanceAbsenceController.ConflictingRecord[] conflictsBeforeResolution = HOT_FreelanceAbsenceController.getConflictsForTimePeriod(
@@ -204,6 +204,8 @@ private class HOT_FreelanceAbsenceControllerTest {
             true
         );
 
+        System.debug('Andre ' + conflictsBeforeResolution);
+
         Test.startTest();
         absenceId = HOT_FreelanceAbsenceController.createAbsenceAndResolveConflicts(
             absenceStart.getTime(),
@@ -211,7 +213,9 @@ private class HOT_FreelanceAbsenceControllerTest {
             'Vacation',
             true
         );
+
         Test.stopTest();
+        System.debug('Andre' + absenceId);
 
         HOT_FreelanceAbsenceController.ConflictingRecord[] conflictsAfterResolution = HOT_FreelanceAbsenceController.getConflictsForTimePeriod(
             absenceStart.getTime(),
@@ -219,12 +223,16 @@ private class HOT_FreelanceAbsenceControllerTest {
             true
         );
 
+        System.debug('Andre' + conflictsAfterResolution);
+
         ResourceAbsence absence = [
             SELECT Id
             FROM ResourceAbsence
             WHERE Id = :absenceId
             LIMIT 1
         ];
+
+        System.debug('Andre' + absence);
 
         Event[] relatedEvents = [
             SELECT Id

--- a/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceControllerTest.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_FreelanceAbsenceControllerTest.cls
@@ -147,28 +147,82 @@ private class HOT_FreelanceAbsenceControllerTest {
     static void createAbsenceAndResolveConflictsTest() {
         Datetime absenceStart = Datetime.now().addHours(ABSENCE_START_TIME_OFFSET_IN_HOURS).addMinutes(1);
         Datetime absenceEnd = absenceStart.addHours(ABSENCE_DURATION_IN_HOURS).addMinutes(1);
+        Id absenceId = null;
         HOT_FreelanceAbsenceController.ConflictingRecord[] conflictsBeforeResolution = HOT_FreelanceAbsenceController.getConflictsForTimePeriod(
             absenceStart.getTime(),
-            absenceEnd.getTime()
+            absenceEnd.getTime(),
+            false
         );
 
         Test.startTest();
-        HOT_FreelanceAbsenceController.createAbsenceAndResolveConflicts(
+        absenceId = HOT_FreelanceAbsenceController.createAbsenceAndResolveConflicts(
             absenceStart.getTime(),
             absenceEnd.getTime(),
-            'Vacation'
+            'Vacation',
+            false
         );
         Test.stopTest();
 
         HOT_FreelanceAbsenceController.ConflictingRecord[] conflictsAfterResolution = HOT_FreelanceAbsenceController.getConflictsForTimePeriod(
             absenceStart.getTime(),
-            absenceEnd.getTime()
+            absenceEnd.getTime(),
+            false
         );
 
         ResourceAbsence absence = [
             SELECT Id
             FROM ResourceAbsence
-            WHERE Start = :absenceStart AND End = :absenceEnd
+            WHERE Id = :absenceId
+            LIMIT 1
+        ];
+
+        Event[] relatedEvents = [
+            SELECT Id
+            FROM Event
+            WHERE WhatId = :absence.Id
+        ];
+
+        System.assert(
+            relatedEvents.size() == 1 &&
+                absence != null &&
+                conflictsBeforeResolution.size() == CONFLICTING_SA_COUNT + CONFLICTING_WAGE_CLAIM_COUNT &&
+                conflictsAfterResolution.isEmpty(),
+            'Should remove conflicts for given time period and create absence'
+        );
+    }
+
+    @IsTest
+    static void createAbsenceAndResolveConflictsWholeDayTest() {
+        Datetime absenceStart = Datetime.now().addHours(ABSENCE_START_TIME_OFFSET_IN_HOURS).addMinutes(1);
+        absenceStart = Datetime.newInstance(absenceStart.year(), absenceStart.month(), absenceStart.day());
+        Datetime absenceEnd = absenceStart;
+        Id absenceId = null;
+
+        HOT_FreelanceAbsenceController.ConflictingRecord[] conflictsBeforeResolution = HOT_FreelanceAbsenceController.getConflictsForTimePeriod(
+            absenceStart.getTime(),
+            absenceEnd.getTime(),
+            true
+        );
+
+        Test.startTest();
+        absenceId = HOT_FreelanceAbsenceController.createAbsenceAndResolveConflicts(
+            absenceStart.getTime(),
+            absenceEnd.getTime(),
+            'Vacation',
+            true
+        );
+        Test.stopTest();
+
+        HOT_FreelanceAbsenceController.ConflictingRecord[] conflictsAfterResolution = HOT_FreelanceAbsenceController.getConflictsForTimePeriod(
+            absenceStart.getTime(),
+            absenceEnd.getTime(),
+            true
+        );
+
+        ResourceAbsence absence = [
+            SELECT Id
+            FROM ResourceAbsence
+            WHERE Id = :absenceId
             LIMIT 1
         ];
 
@@ -195,7 +249,8 @@ private class HOT_FreelanceAbsenceControllerTest {
             HOT_FreelanceAbsenceController.createAbsenceAndResolveConflicts(
                 Datetime.now().getTime(),
                 Datetime.now().addMinutes(1).getTime(),
-                'Invalid type'
+                'Invalid type',
+                false
             );
         } catch (Exception e) {
             createAbsenceException = e;
@@ -217,7 +272,8 @@ private class HOT_FreelanceAbsenceControllerTest {
             HOT_FreelanceAbsenceController.createAbsenceAndResolveConflicts(
                 Datetime.now().getTime(),
                 Datetime.now().addMinutes(-1).getTime(),
-                'Vacation'
+                'Vacation',
+                false
             );
         } catch (Exception e) {
             createAbsenceException = e;
@@ -239,7 +295,8 @@ private class HOT_FreelanceAbsenceControllerTest {
         Test.startTest();
         HOT_FreelanceAbsenceController.ConflictingRecord[] conflicts = HOT_FreelanceAbsenceController.getConflictsForTimePeriod(
             absenceStart.getTime(),
-            absenceEnd.getTime()
+            absenceEnd.getTime(),
+            false
         );
         Test.stopTest();
 
@@ -258,7 +315,11 @@ private class HOT_FreelanceAbsenceControllerTest {
 
         Test.startTest();
         try {
-            HOT_FreelanceAbsenceController.getConflictsForTimePeriod(absenceStart.getTime(), absenceEnd.getTime());
+            HOT_FreelanceAbsenceController.getConflictsForTimePeriod(
+                absenceStart.getTime(),
+                absenceEnd.getTime(),
+                false
+            );
         } catch (Exception e) {
             getConflictsException = e;
         }
@@ -277,7 +338,8 @@ private class HOT_FreelanceAbsenceControllerTest {
         Datetime absenceEnd = absenceStart.addHours(ABSENCE_DURATION_IN_HOURS).addMinutes(1);
         HOT_FreelanceAbsenceController.ConflictingRecord[] conflictsBeforeResolution = HOT_FreelanceAbsenceController.getConflictsForTimePeriod(
             absenceStart.getTime(),
-            absenceEnd.getTime()
+            absenceEnd.getTime(),
+            false
         );
 
         Test.startTest();
@@ -286,7 +348,8 @@ private class HOT_FreelanceAbsenceControllerTest {
 
         HOT_FreelanceAbsenceController.ConflictingRecord[] conflictsAfterResolution = HOT_FreelanceAbsenceController.getConflictsForTimePeriod(
             absenceStart.getTime(),
-            absenceEnd.getTime()
+            absenceEnd.getTime(),
+            false
         );
 
         System.assert(


### PR DESCRIPTION
- Endrer tekst ved konflikter til forslag fra TOLK-2483
- Lager man fravær fra dagsvisning settes nå foreslått tid fra kl 12 til 13 for valgt dag
- Lar tolk krysse av for heldags, hvor man slipper å velge tidspunkt. Tid for fravær starter 00:00 første dag og avlustted midnatt siste dag.
- -  Hendelser har per nå ikke noe flagg for heldagshendelse, så dette har kun betydning ved oppretting. Må eventuelt utvide logikk i selve kalenderen til å hente info om heldagshendelser, som må være satt på relatert Event record om det er ønskelig å gjøre noe med dette i fremtiden.
- Ved endring av startdato vil sluttdato automatisk settes til dagen etter samme klokkeslett. Denne oppførselen slutter så fort tolk har satt et tidspunkt for slutt manuelt.
- Endrer tekst for fraværstype til norsk ved bekreftelse av nytt fravær.