### PR TITLE
TOLK-2804 : Alltid vise norske tidssoner v2

### DIFF
--- a/force-app/main/dialogue/external-components/lwc/hot_messagingCommunityThreadViewer/hot_messagingCommunityThreadViewer.js
+++ b/force-app/main/dialogue/external-components/lwc/hot_messagingCommunityThreadViewer/hot_messagingCommunityThreadViewer.js
@@ -6,7 +6,7 @@ import markThreadAsRead from '@salesforce/apex/HOT_MessageHelper.markThreadAsRea
 import { refreshApex } from '@salesforce/apex';
 import getContactId from '@salesforce/apex/HOT_MessageHelper.getUserContactId';
 import getRelatedObjectDetails from '@salesforce/apex/HOT_MessageHelper.getRelatedObjectDetails';
-import { formatDate } from 'c/datetimeFormatter';
+import { formatDate, formatDatetimeinterval, formatDatetime } from 'c/datetimeFormatterNorwegianTime';
 import getServiceAppointmentDetails from '@salesforce/apex/HOT_MyServiceAppointmentListController.getServiceAppointmentDetails';
 import getInterestedResourceDetails from '@salesforce/apex/HOT_InterestedResourcesListController.getInterestedResourceDetails';
 import getWageClaimDetails from '@salesforce/apex/HOT_WageClaimListController.getWageClaimDetails';
@@ -16,7 +16,7 @@ import createmsg from '@salesforce/apex/HOT_MessageHelper.createMessage';
 import { getParametersFromURL } from 'c/hot_URIDecoder';
 
 import setLastMessageFrom from '@salesforce/apex/HOT_MessageHelper.setLastMessageFrom';
-import { formatRecord } from 'c/datetimeFormatter';
+import { formatRecord } from 'c/datetimeFormatterNorwegianTime';
 
 import getThreadDetails from '@salesforce/apex/HOT_ThreadDetailController.getThreadDetails';
 
@@ -384,44 +384,12 @@ export default class hot_messagingCommunityThreadViewer extends NavigationMixin(
                     getServiceAppointmentDetails({ recordId: key }).then((result) => {
                         this.serviceAppointment = result;
                         this.address = this.serviceAppointment.HOT_AddressFormated__c;
-                        let startTimeFormatted = new Date(result.EarliestStartTime);
-                        let endTimeFormatted = new Date(result.DueDate);
-                        this.serviceAppointment.StartAndEndDate =
-                            startTimeFormatted.getDate() +
-                            '.' +
-                            (startTimeFormatted.getMonth() + 1) +
-                            '.' +
-                            startTimeFormatted.getFullYear() +
-                            ', ' +
-                            ('0' + startTimeFormatted.getHours()).substr(-2) +
-                            ':' +
-                            ('0' + startTimeFormatted.getMinutes()).substr(-2) +
-                            ' - ' +
-                            ('0' + endTimeFormatted.getHours()).substr(-2) +
-                            ':' +
-                            ('0' + endTimeFormatted.getMinutes()).substr(-2);
-                        let actualstartTimeFormatted = new Date(result.ActualStartTime);
-                        let actualendTimeFormatted = new Date(result.ActualEndTime);
-                        this.serviceAppointment.ActualStartTime =
-                            actualstartTimeFormatted.getDate() +
-                            '.' +
-                            (actualstartTimeFormatted.getMonth() + 1) +
-                            '.' +
-                            actualstartTimeFormatted.getFullYear() +
-                            ' ' +
-                            ('0' + actualstartTimeFormatted.getHours()).substr(-2) +
-                            ':' +
-                            ('0' + actualstartTimeFormatted.getMinutes()).substr(-2);
-                        this.serviceAppointment.ActualEndTime =
-                            actualendTimeFormatted.getDate() +
-                            '.' +
-                            (actualendTimeFormatted.getMonth() + 1) +
-                            '.' +
-                            actualendTimeFormatted.getFullYear() +
-                            ' ' +
-                            ('0' + actualendTimeFormatted.getHours()).substr(-2) +
-                            ':' +
-                            ('0' + actualendTimeFormatted.getMinutes()).substr(-2);
+                        this.serviceAppointment.StartAndEndDate = formatDatetimeinterval(
+                            result.EarliestStartTime,
+                            result.DueDate
+                        );
+                        this.serviceAppointment.ActualStartTime = formatDatetime(result.ActualStartTime);
+                        this.serviceAppointment.ActualEndTime = formatDatetime(result.ActualEndTime);
                         if (this.serviceAppointment.ActualStartTime.includes('NaN')) {
                             this.serviceAppointment.ActualStartTime = '';
                         }
@@ -506,22 +474,10 @@ export default class hot_messagingCommunityThreadViewer extends NavigationMixin(
                 if (result[key] == 'IR') {
                     getInterestedResourceDetails({ recordId: key }).then((result) => {
                         this.interestedResource = result;
-                        let startTimeFormatted = new Date(result.ServiceAppointmentStartTime__c);
-                        let endTimeFormatted = new Date(result.ServiceAppointmentEndTime__c);
-                        this.interestedResource.StartAndEndDate =
-                            startTimeFormatted.getDate() +
-                            '.' +
-                            (startTimeFormatted.getMonth() + 1) +
-                            '.' +
-                            startTimeFormatted.getFullYear() +
-                            ', ' +
-                            ('0' + startTimeFormatted.getHours()).substr(-2) +
-                            ':' +
-                            ('0' + startTimeFormatted.getMinutes()).substr(-2) +
-                            ' - ' +
-                            ('0' + endTimeFormatted.getHours()).substr(-2) +
-                            ':' +
-                            ('0' + endTimeFormatted.getMinutes()).substr(-2);
+                        this.interestedResource.StartAndEndDate = formatDatetimeinterval(
+                            result.ServiceAppointmentStartTime__c,
+                            result.ServiceAppointmentEndTime__c
+                        );
                         let DeadlineDateTimeFormatted = new Date(this.interestedResource.AppointmentDeadlineDate__c);
                         this.interestedResource.AppointmentDeadlineDate__c =
                             DeadlineDateTimeFormatted.getDate() +
@@ -553,22 +509,10 @@ export default class hot_messagingCommunityThreadViewer extends NavigationMixin(
                 if (result[key] == 'WC') {
                     getWageClaimDetails({ recordId: key }).then((result) => {
                         this.wageClaim = result;
-                        let startTimeFormatted = new Date(this.wageClaim.StartTime__c);
-                        let endTimeFormatted = new Date(this.wageClaim.EndTime__c);
-                        this.wageClaim.StartAndEndDate =
-                            startTimeFormatted.getDate() +
-                            '.' +
-                            (startTimeFormatted.getMonth() + 1) +
-                            '.' +
-                            startTimeFormatted.getFullYear() +
-                            ', ' +
-                            ('0' + startTimeFormatted.getHours()).substr(-2) +
-                            ':' +
-                            ('0' + startTimeFormatted.getMinutes()).substr(-2) +
-                            ' - ' +
-                            ('0' + endTimeFormatted.getHours()).substr(-2) +
-                            ':' +
-                            ('0' + endTimeFormatted.getMinutes()).substr(-2);
+                        this.wageClaim.StartAndEndDate = formatDatetimeinterval(
+                            this.wageClaim.StartTime__c,
+                            this.wageClaim.EndTime__c
+                        );
                         this.isWCDetails = true;
                         this.template.querySelector('.serviceAppointmentDetails').classList.remove('hidden');
                     });

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_wrap/hot_calendar_wrap.css
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_wrap/hot_calendar_wrap.css
@@ -80,3 +80,30 @@
         padding-bottom: 1rem;
     }
 }
+.navno-dekorator.alertstripe {
+    display: block;
+    padding: 1rem 1rem 1rem 0rem;
+    border-radius: 4px;
+    display: flex;
+    align-content: center;
+    border-radius: 0.25rem;
+    color: #3e3832;
+    max-width: fit-content;
+    margin: auto;
+    margin-top: 0.5rem;
+}
+
+.navno-dekorator.alertstripe--advarsel {
+    border: 1px solid #ff9100;
+    background-color: #ffe9cc;
+    margin-bottom: 0.2rem;
+}
+.navno-dekorator.alertstripe__ikon {
+    margin-right: 0.75rem;
+    margin-left: 0.75rem;
+    display: flex;
+    top: 1rem;
+    flex-shrink: 0;
+    height: 24px;
+    width: 24px;
+}

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_wrap/hot_calendar_wrap.html
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_wrap/hot_calendar_wrap.html
@@ -1,10 +1,22 @@
 <template>
-    <div class="main">
-        <div class="content">
-            <button class="link" type="button" onclick={toggleCalendar}>
-                <h2 class="typo-undertittel">{buttonLabel}</h2>
-            </button>
+    <template lwc:if={isUserInNorwegianTimeZone}>
+        <div class="main">
+            <div class="content">
+                <button class="link" type="button" onclick={toggleCalendar}>
+                    <h2 class="typo-undertittel">{buttonLabel}</h2>
+                </button>
+            </div>
         </div>
-    </div>
+    </template>
+
+    <template lwc:else>
+        <div class="navno-dekorator alertstripe navno-dekorator alertstripe--advarsel">
+            <img class="navno-dekorator alertstripe__ikon" src={warningicon} alt="advarsel-ikon" />
+            <div class="alertstripe__tekst">
+                <p>Kalender er ikke tilgjengelig når du befinner deg utenfor norsk tidssone.</p>
+            </div>
+        </div>
+    </template>
+
     <c-hot_calendar lwc:if={showCalendar}></c-hot_calendar>
 </template>

--- a/force-app/main/freelanceCalendar/lwc/hot_calendar_wrap/hot_calendar_wrap.js
+++ b/force-app/main/freelanceCalendar/lwc/hot_calendar_wrap/hot_calendar_wrap.js
@@ -1,9 +1,12 @@
 import { LightningElement, track } from 'lwc';
+import icons from '@salesforce/resourceUrl/icons';
 
 export default class Hot_calendar_wrap extends LightningElement {
     @track showCalendar = false;
+    @track isUserInNorwegianTimeZone = true;
     @track buttonLabel = 'Kalender'; // Initial label
     static STATE_KEY = 'calendarWrapState';
+    warningicon = icons + '/warningicon.svg';
 
     toggleCalendar() {
         this.showCalendar = !this.showCalendar;
@@ -15,6 +18,7 @@ export default class Hot_calendar_wrap extends LightningElement {
     }
 
     connectedCallback() {
+        this.checkTimeZone();
         const state = sessionStorage.getItem(Hot_calendar_wrap.STATE_KEY);
         if (state != null) {
             const parsedState = JSON.parse(state);
@@ -28,5 +32,10 @@ export default class Hot_calendar_wrap extends LightningElement {
             showCalendar: this.showCalendar
         };
         sessionStorage.setItem(Hot_calendar_wrap.STATE_KEY, JSON.stringify(state));
+    }
+    checkTimeZone() {
+        const osloTime = new Date().toLocaleString('no-NB', { timeZone: 'Europe/Oslo' });
+        const userTime = new Date().toLocaleString('no-NB');
+        this.isUserInNorwegianTimeZone = osloTime === userTime;
     }
 }

--- a/force-app/main/freelanceCommunity/classes/lwc/hot_informationModal/hot_informationModal.js
+++ b/force-app/main/freelanceCommunity/classes/lwc/hot_informationModal/hot_informationModal.js
@@ -316,12 +316,6 @@ export default class Hot_informationModal extends NavigationMixin(LightningModal
                     );
                     this.serviceAppointment.ActualStartTime = formatDatetime(result.ActualStartTime);
                     this.serviceAppointment.ActualEndTime = formatDatetime(result.ActualEndTime);
-                    if (this.serviceAppointment.ActualStartTime.includes('NaN')) {
-                        this.serviceAppointment.ActualStartTime = '';
-                    }
-                    if (this.serviceAppointment.ActualEndTime.includes('NaN')) {
-                        this.serviceAppointment.ActualEndTime = '';
-                    }
                     if (
                         this.serviceAppointment &&
                         this.serviceAppointment.HOT_Request__r &&

--- a/force-app/main/freelanceCommunity/classes/lwc/hot_informationModal/hot_informationModal.js
+++ b/force-app/main/freelanceCommunity/classes/lwc/hot_informationModal/hot_informationModal.js
@@ -16,7 +16,7 @@ import getThreadIdWC from '@salesforce/apex/HOT_WageClaimListController.getThrea
 import getServiceResource from '@salesforce/apex/HOT_Utility.getServiceResource';
 import getWageClaimDetails from '@salesforce/apex/HOT_WageClaimListController.getWageClaimDetails';
 import refreshApex from '@salesforce/apex';
-import { formatDatetimeinterval, formatDateTime } from 'c/datetimeFormatterNorwegianTime';
+import { formatDatetimeinterval, formatDatetime } from 'c/datetimeFormatterNorwegianTime';
 import HOT_ConfirmationModal from 'c/hot_confirmationModal';
 
 export default class Hot_informationModal extends NavigationMixin(LightningModal) {
@@ -314,8 +314,8 @@ export default class Hot_informationModal extends NavigationMixin(LightningModal
                         result.EarliestStartTime,
                         result.DueDate
                     );
-                    this.serviceAppointment.ActualStartTime = formatDateTime(result.ActualStartTime);
-                    this.serviceAppointment.ActualEndTime = formatDateTime(result.ActualEndTime);
+                    this.serviceAppointment.ActualStartTime = formatDatetime(result.ActualStartTime);
+                    this.serviceAppointment.ActualEndTime = formatDatetime(result.ActualEndTime);
                     if (this.serviceAppointment.ActualStartTime.includes('NaN')) {
                         this.serviceAppointment.ActualStartTime = '';
                     }

--- a/force-app/main/freelanceCommunity/classes/lwc/hot_informationModal/hot_informationModal.js
+++ b/force-app/main/freelanceCommunity/classes/lwc/hot_informationModal/hot_informationModal.js
@@ -16,6 +16,7 @@ import getThreadIdWC from '@salesforce/apex/HOT_WageClaimListController.getThrea
 import getServiceResource from '@salesforce/apex/HOT_Utility.getServiceResource';
 import getWageClaimDetails from '@salesforce/apex/HOT_WageClaimListController.getWageClaimDetails';
 import refreshApex from '@salesforce/apex';
+import { formatDatetimeinterval, formatDateTime } from 'c/datetimeFormatterNorwegianTime';
 import HOT_ConfirmationModal from 'c/hot_confirmationModal';
 
 export default class Hot_informationModal extends NavigationMixin(LightningModal) {
@@ -284,22 +285,10 @@ export default class Hot_informationModal extends NavigationMixin(LightningModal
         this.isLoading = true;
         getWageClaimDetails({ recordId: recordId }).then((result) => {
             this.wageClaim = result;
-            let startTimeFormatted = new Date(this.wageClaim.StartTime__c);
-            let endTimeFormatted = new Date(this.wageClaim.EndTime__c);
-            this.wageClaim.StartAndEndDate =
-                startTimeFormatted.getDate() +
-                '.' +
-                (startTimeFormatted.getMonth() + 1) +
-                '.' +
-                startTimeFormatted.getFullYear() +
-                ', ' +
-                ('0' + startTimeFormatted.getHours()).substr(-2) +
-                ':' +
-                ('0' + startTimeFormatted.getMinutes()).substr(-2) +
-                ' - ' +
-                ('0' + endTimeFormatted.getHours()).substr(-2) +
-                ':' +
-                ('0' + endTimeFormatted.getMinutes()).substr(-2);
+            this.wageClaim.StartAndEndDate = formatDatetimeinterval(
+                this.wageClaim.StartTime__c,
+                this.wageClaim.EndTime__c
+            );
             this.isWCDetails = true;
             this.isLoading = false;
         });
@@ -321,44 +310,12 @@ export default class Hot_informationModal extends NavigationMixin(LightningModal
                     this.ordererPhoneNumber = '';
                     this.ownerName = '';
                     this.serviceAppointment = result;
-                    let startTimeFormatted = new Date(result.EarliestStartTime);
-                    let endTimeFormatted = new Date(result.DueDate);
-                    this.serviceAppointment.StartAndEndDate =
-                        startTimeFormatted.getDate() +
-                        '.' +
-                        (startTimeFormatted.getMonth() + 1) +
-                        '.' +
-                        startTimeFormatted.getFullYear() +
-                        ', ' +
-                        ('0' + startTimeFormatted.getHours()).substr(-2) +
-                        ':' +
-                        ('0' + startTimeFormatted.getMinutes()).substr(-2) +
-                        ' - ' +
-                        ('0' + endTimeFormatted.getHours()).substr(-2) +
-                        ':' +
-                        ('0' + endTimeFormatted.getMinutes()).substr(-2);
-                    let actualstartTimeFormatted = new Date(result.ActualStartTime);
-                    let actualendTimeFormatted = new Date(result.ActualEndTime);
-                    this.serviceAppointment.ActualStartTime =
-                        actualstartTimeFormatted.getDate() +
-                        '.' +
-                        (actualstartTimeFormatted.getMonth() + 1) +
-                        '.' +
-                        actualstartTimeFormatted.getFullYear() +
-                        ' ' +
-                        ('0' + actualstartTimeFormatted.getHours()).substr(-2) +
-                        ':' +
-                        ('0' + actualstartTimeFormatted.getMinutes()).substr(-2);
-                    this.serviceAppointment.ActualEndTime =
-                        actualendTimeFormatted.getDate() +
-                        '.' +
-                        (actualendTimeFormatted.getMonth() + 1) +
-                        '.' +
-                        actualendTimeFormatted.getFullYear() +
-                        ' ' +
-                        ('0' + actualendTimeFormatted.getHours()).substr(-2) +
-                        ':' +
-                        ('0' + actualendTimeFormatted.getMinutes()).substr(-2);
+                    this.serviceAppointment.StartAndEndDate = formatDatetimeinterval(
+                        result.EarliestStartTime,
+                        result.DueDate
+                    );
+                    this.serviceAppointment.ActualStartTime = formatDateTime(result.ActualStartTime);
+                    this.serviceAppointment.ActualEndTime = formatDateTime(result.ActualEndTime);
                     if (this.serviceAppointment.ActualStartTime.includes('NaN')) {
                         this.serviceAppointment.ActualStartTime = '';
                     }

--- a/force-app/main/freelanceCommunity/lwc/hot_frilanstolkThreadList/hot_frilanstolkThreadList.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_frilanstolkThreadList/hot_frilanstolkThreadList.js
@@ -2,6 +2,7 @@ import { LightningElement, wire, track } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import getMyThreads from '@salesforce/apex/HOT_ThreadListController.getMyThreadsFreelance';
 import getContactId from '@salesforce/apex/HOT_MessageHelper.getUserContactId';
+import { formatDatetime } from 'c/datetimeFormatterNorwegianTime';
 import { refreshApex } from '@salesforce/apex';
 
 export default class Hot_frilanstolkThreadList extends NavigationMixin(LightningElement) {
@@ -236,28 +237,28 @@ export default class Hot_frilanstolkThreadList extends NavigationMixin(Lightning
                         read: !String(x.HOT_Thread_read_by__c).includes(contactId) ? false : true,
                         lastMessage: this.formatDateTime(x.CRM_Latest_Message_Datetime__c),
                         appointmentDate: x.HOT_AppointmentStartTime__c,
-                        appointmentStart: this.formatDateTime(x.HOT_AppointmentStartTime__c)
+                        appointmentStart: formatDatetime(x.HOT_AppointmentStartTime__c)
                     }));
                     this.interpreterThreads = this.unmappedInterpreterThreads.map((x) => ({
                         ...x,
                         read: !String(x.HOT_Thread_read_by__c).includes(contactId) ? false : true,
                         lastMessage: this.formatDateTime(x.CRM_Latest_Message_Datetime__c),
                         appointmentDate: x.HOT_AppointmentStartTime__c,
-                        appointmentStart: this.formatDateTime(x.HOT_AppointmentStartTime__c)
+                        appointmentStart: formatDatetime(x.HOT_AppointmentStartTime__c)
                     }));
                     this.wageClaimThreads = this.unmappedWageClaimThreads.map((x) => ({
                         ...x,
                         read: !String(x.HOT_Thread_read_by__c).includes(contactId) ? false : true,
                         lastMessage: this.formatDateTime(x.CRM_Latest_Message_Datetime__c),
                         appointmentDate: x.HOT_AppointmentStartTime__c,
-                        appointmentStart: this.formatDateTime(x.HOT_AppointmentStartTime__c)
+                        appointmentStart: formatDatetime(x.HOT_AppointmentStartTime__c)
                     }));
                     this.interpreterInterpreterThreads = this.unmappedInterpreterInterpreterThreads.map((x) => ({
                         ...x,
                         read: !String(x.HOT_Thread_read_by__c).includes(contactId) ? false : true,
                         lastMessage: this.formatDateTime(x.CRM_Latest_Message_Datetime__c),
                         appointmentDate: x.HOT_AppointmentStartTime__c,
-                        appointmentStart: this.formatDateTime(x.HOT_AppointmentStartTime__c)
+                        appointmentStart: formatDatetime(x.HOT_AppointmentStartTime__c)
                     }));
 
                     this.noThreads = this.threads.length === 0;

--- a/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
@@ -10,7 +10,7 @@ import { refreshApex } from '@salesforce/apex';
 import { getParametersFromURL } from 'c/hot_URIDecoder';
 import { columns, mobileColumns, iconByValue } from './columns';
 import { defaultFilters, compare } from './filters';
-import { formatRecord } from 'c/datetimeFormatter';
+import { formatRecord } from 'c/datetimeFormatterNorwegianTime';
 import { NavigationMixin } from 'lightning/navigation';
 
 import Hot_interestedResourcesListModal from 'c/hot_interestedResourcesListModal';

--- a/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
@@ -3,14 +3,13 @@ import getInterestedResources from '@salesforce/apex/HOT_InterestedResourcesList
 import getMyThreads from '@salesforce/apex/HOT_ThreadListController.getMyThreadsIR';
 import getInterestedResourceDetails from '@salesforce/apex/HOT_InterestedResourcesListController.getInterestedResourceDetails';
 import checkAccessToSA from '@salesforce/apex/HOT_InterestedResourcesListController.checkAccessToSA';
-
+import { formatRecord, formatDatetimeinterval } from 'c/datetimeFormatterNorwegianTime';
 import getContactId from '@salesforce/apex/HOT_MessageHelper.getUserContactId';
 import getServiceResource from '@salesforce/apex/HOT_Utility.getServiceResource';
 import { refreshApex } from '@salesforce/apex';
 import { getParametersFromURL } from 'c/hot_URIDecoder';
 import { columns, mobileColumns, iconByValue } from './columns';
 import { defaultFilters, compare } from './filters';
-import { formatRecord } from 'c/datetimeFormatterNorwegianTime';
 import { NavigationMixin } from 'lightning/navigation';
 
 import Hot_interestedResourcesListModal from 'c/hot_interestedResourcesListModal';
@@ -160,7 +159,7 @@ export default class Hot_interestedResourcesList extends NavigationMixin(Lightni
                             ...appointment,
                             IsUnreadMessage: status,
                             startAndEndDateWeekday:
-                                this.formatDatetime(
+                                formatDatetimeinterval(
                                     appointment.ServiceAppointmentStartTime__c,
                                     appointment.ServiceAppointmentEndTime__c
                                 ) +
@@ -191,22 +190,6 @@ export default class Hot_interestedResourcesList extends NavigationMixin(Lightni
         //this.sendRecords();
         this.sendFilters();
         this.applyFilter({ detail: { filterArray: this.filters, setRecords: true } });
-    }
-
-    formatDatetime(Start, DueDate) {
-        const datetimeStart = new Date(Start);
-        const dayStart = datetimeStart.getDate().toString().padStart(2, '0');
-        const monthStart = (datetimeStart.getMonth() + 1).toString().padStart(2, '0');
-        const yearStart = datetimeStart.getFullYear();
-        const hoursStart = datetimeStart.getHours().toString().padStart(2, '0');
-        const minutesStart = datetimeStart.getMinutes().toString().padStart(2, '0');
-
-        const datetimeEnd = new Date(DueDate);
-        const hoursEnd = datetimeEnd.getHours().toString().padStart(2, '0');
-        const minutesEnd = datetimeEnd.getMinutes().toString().padStart(2, '0');
-
-        const formattedDatetime = `${dayStart}.${monthStart}.${yearStart} ${hoursStart}:${minutesStart} - ${hoursEnd}:${minutesEnd}`;
-        return formattedDatetime;
     }
 
     datetimeFields = [

--- a/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
@@ -5,7 +5,7 @@ import Hot_informationModal from 'c/hot_informationModal';
 import { NavigationMixin } from 'lightning/navigation';
 import { columns, mobileColumns } from './columns';
 import { defaultFilters, compare } from './filters';
-import { formatRecord } from 'c/datetimeFormatter';
+import { formatRecord } from 'c/datetimeFormatterNorwegianTime';
 import { refreshApex } from '@salesforce/apex';
 import { getParametersFromURL } from 'c/hot_URIDecoder';
 

--- a/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
@@ -5,7 +5,7 @@ import Hot_informationModal from 'c/hot_informationModal';
 import { NavigationMixin } from 'lightning/navigation';
 import { columns, mobileColumns } from './columns';
 import { defaultFilters, compare } from './filters';
-import { formatRecord } from 'c/datetimeFormatterNorwegianTime';
+import { formatRecord, formatDatetimeinterval } from 'c/datetimeFormatterNorwegianTime';
 import { refreshApex } from '@salesforce/apex';
 import { getParametersFromURL } from 'c/hot_URIDecoder';
 
@@ -116,7 +116,9 @@ export default class Hot_myServiceAppointments extends NavigationMixin(Lightning
             this.records = tempRecords.map((x) => ({
                 ...x,
                 startAndEndDateWeekday:
-                    this.formatDatetime(x.EarliestStartTime, x.DueDate) + ' ' + this.getDayOfWeek(x.EarliestStartTime)
+                    formatDatetimeinterval(x.EarliestStartTime, x.DueDate) +
+                    ' ' +
+                    this.getDayOfWeek(x.EarliestStartTime)
             }));
             this.initialServiceAppointments = [...this.records];
             this.refresh();
@@ -132,21 +134,6 @@ export default class Hot_myServiceAppointments extends NavigationMixin(Lightning
         this.sendRecords();
         this.sendFilters();
         this.applyFilter({ detail: { filterArray: this.filters, setRecords: true } });
-    }
-    formatDatetime(Start, DueDate) {
-        const datetimeStart = new Date(Start);
-        const dayStart = datetimeStart.getDate().toString().padStart(2, '0');
-        const monthStart = (datetimeStart.getMonth() + 1).toString().padStart(2, '0');
-        const yearStart = datetimeStart.getFullYear();
-        const hoursStart = datetimeStart.getHours().toString().padStart(2, '0');
-        const minutesStart = datetimeStart.getMinutes().toString().padStart(2, '0');
-
-        const datetimeEnd = new Date(DueDate);
-        const hoursEnd = datetimeEnd.getHours().toString().padStart(2, '0');
-        const minutesEnd = datetimeEnd.getMinutes().toString().padStart(2, '0');
-
-        const formattedDatetime = `${dayStart}.${monthStart}.${yearStart} ${hoursStart}:${minutesStart} - ${hoursEnd}:${minutesEnd}`;
-        return formattedDatetime;
     }
 
     datetimeFields = [

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
@@ -5,7 +5,7 @@ import getServiceResource from '@salesforce/apex/HOT_Utility.getServiceResource'
 import { columns, inDetailsColumns, mobileColumns } from './columns';
 import { refreshApex } from '@salesforce/apex';
 import { defaultFilters, compare, setDefaultFilters } from './filters';
-import { formatRecord } from 'c/datetimeFormatter';
+import { formatRecord } from 'c/datetimeFormatterNorwegianTime';
 import Hot_openServiceAppointmentsModal from 'c/hot_openServiceAppointmentsModal';
 
 export default class Hot_openServiceAppointments extends LightningElement {

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
@@ -5,7 +5,7 @@ import getServiceResource from '@salesforce/apex/HOT_Utility.getServiceResource'
 import { columns, inDetailsColumns, mobileColumns } from './columns';
 import { refreshApex } from '@salesforce/apex';
 import { defaultFilters, compare, setDefaultFilters } from './filters';
-import { formatRecord } from 'c/datetimeFormatterNorwegianTime';
+import { formatRecord, formatDatetimeinterval } from 'c/datetimeFormatterNorwegianTime';
 import Hot_openServiceAppointmentsModal from 'c/hot_openServiceAppointmentsModal';
 
 export default class Hot_openServiceAppointments extends LightningElement {
@@ -141,21 +141,7 @@ export default class Hot_openServiceAppointments extends LightningElement {
             }
         }
     }
-    formatDatetime(Start, DueDate) {
-        const datetimeStart = new Date(Start);
-        const dayStart = datetimeStart.getDate().toString().padStart(2, '0');
-        const monthStart = (datetimeStart.getMonth() + 1).toString().padStart(2, '0');
-        const yearStart = datetimeStart.getFullYear();
-        const hoursStart = datetimeStart.getHours().toString().padStart(2, '0');
-        const minutesStart = datetimeStart.getMinutes().toString().padStart(2, '0');
 
-        const datetimeEnd = new Date(DueDate);
-        const hoursEnd = datetimeEnd.getHours().toString().padStart(2, '0');
-        const minutesEnd = datetimeEnd.getMinutes().toString().padStart(2, '0');
-
-        const formattedDatetime = `${dayStart}.${monthStart}.${yearStart} ${hoursStart}:${minutesStart} - ${hoursEnd}:${minutesEnd}`;
-        return formattedDatetime;
-    }
     noServiceAppointments = false;
     initialServiceAppointments = [];
     @track records = [];
@@ -171,7 +157,9 @@ export default class Hot_openServiceAppointments extends LightningElement {
                 ...x,
                 isUrgent: x.HOT_IsUrgent__c,
                 startAndEndDateWeekday:
-                    this.formatDatetime(x.EarliestStartTime, x.DueDate) + ' ' + this.getDayOfWeek(x.EarliestStartTime),
+                    formatDatetimeinterval(x.EarliestStartTime, x.DueDate) +
+                    ' ' +
+                    this.getDayOfWeek(x.EarliestStartTime),
                 weekday: this.getDayOfWeek(x.EarliestStartTime)
             }));
 

--- a/force-app/main/freelanceCommunity/lwc/hot_wantedServiceAppointmentsList/hot_wantedServiceAppointmentsList.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_wantedServiceAppointmentsList/hot_wantedServiceAppointmentsList.js
@@ -8,7 +8,7 @@ import getServiceResource from '@salesforce/apex/HOT_Utility.getServiceResource'
 import { columns, inDetailsColumns, mobileColumns } from './columns';
 import { refreshApex } from '@salesforce/apex';
 import { defaultFilters, compare, setDefaultFilters } from './filters';
-import { formatRecord } from 'c/datetimeFormatterNorwegianTime';
+import { formatRecord, formatDatetimeinterval } from 'c/datetimeFormatterNorwegianTime';
 import Hot_wantedServiceAppointmentsListModal from 'c/hot_wantedServiceAppointmentsListModal';
 
 export default class Hot_wantedServiceAppointmentsList extends LightningElement {
@@ -117,21 +117,6 @@ export default class Hot_wantedServiceAppointmentsList extends LightningElement 
         }
         return dayOfWeekString;
     }
-    formatDatetime(Start, DueDate) {
-        const datetimeStart = new Date(Start);
-        const dayStart = datetimeStart.getDate().toString().padStart(2, '0');
-        const monthStart = (datetimeStart.getMonth() + 1).toString().padStart(2, '0');
-        const yearStart = datetimeStart.getFullYear();
-        const hoursStart = datetimeStart.getHours().toString().padStart(2, '0');
-        const minutesStart = datetimeStart.getMinutes().toString().padStart(2, '0');
-
-        const datetimeEnd = new Date(DueDate);
-        const hoursEnd = datetimeEnd.getHours().toString().padStart(2, '0');
-        const minutesEnd = datetimeEnd.getMinutes().toString().padStart(2, '0');
-
-        const formattedDatetime = `${dayStart}.${monthStart}.${yearStart} ${hoursStart}:${minutesStart} - ${hoursEnd}:${minutesEnd}`;
-        return formattedDatetime;
-    }
 
     @track serviceResource;
     @track serviceResourceId;
@@ -161,7 +146,9 @@ export default class Hot_wantedServiceAppointmentsList extends LightningElement 
                 weekday: this.getDayOfWeek(x.EarliestStartTime),
                 isUrgent: x.HOT_IsUrgent__c,
                 startAndEndDateWeekday:
-                    this.formatDatetime(x.EarliestStartTime, x.DueDate) + ' ' + this.getDayOfWeek(x.EarliestStartTime)
+                    formatDatetimeinterval(x.EarliestStartTime, x.DueDate) +
+                    ' ' +
+                    this.getDayOfWeek(x.EarliestStartTime)
             }));
             this.noServiceAppointments = this.allServiceAppointmentsWired.length === 0;
             let tempRecords = [];

--- a/force-app/main/freelanceCommunity/lwc/hot_wantedServiceAppointmentsList/hot_wantedServiceAppointmentsList.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_wantedServiceAppointmentsList/hot_wantedServiceAppointmentsList.js
@@ -8,7 +8,7 @@ import getServiceResource from '@salesforce/apex/HOT_Utility.getServiceResource'
 import { columns, inDetailsColumns, mobileColumns } from './columns';
 import { refreshApex } from '@salesforce/apex';
 import { defaultFilters, compare, setDefaultFilters } from './filters';
-import { formatRecord } from 'c/datetimeFormatter';
+import { formatRecord } from 'c/datetimeFormatterNorwegianTime';
 import Hot_wantedServiceAppointmentsListModal from 'c/hot_wantedServiceAppointmentsListModal';
 
 export default class Hot_wantedServiceAppointmentsList extends LightningElement {
@@ -210,7 +210,7 @@ export default class Hot_wantedServiceAppointmentsList extends LightningElement 
     getModalSize() {
         return window.screen.width < 768 ? 'full' : 'small';
     }
-    
+
     async showServiceAppointmentDetails() {
         try {
             const modalResult = await Hot_wantedServiceAppointmentsListModal.open({

--- a/force-app/main/userCommunity/lwc/datetimeFormatterNorwegianTime/datetimeFormatterNorwegianTime.js
+++ b/force-app/main/userCommunity/lwc/datetimeFormatterNorwegianTime/datetimeFormatterNorwegianTime.js
@@ -1,0 +1,55 @@
+export function formatDatetime(initialDatetime) {
+    if (initialDatetime === undefined) {
+        return null;
+    }
+    let datetime = new Date(initialDatetime);
+    return (
+        datetime.toLocaleDateString('nb-NO', { timeZone: 'Europe/Oslo' }) +
+        ', ' +
+        datetime.toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Oslo' })
+    );
+}
+
+export function formatDate(initialDate) {
+    if (initialDate === undefined) {
+        return null;
+    }
+    let date = new Date(initialDate);
+    return date.toLocaleDateString('nb-NO', { timeZone: 'Europe/Oslo' });
+}
+
+export function formatDatetimeinterval(initialStart, initialEnd) {
+    if (initialStart === undefined || initialEnd === undefined) {
+        return null;
+    }
+    let start = new Date(initialStart);
+    let end = new Date(initialEnd);
+    return (
+        start.toLocaleDateString('nb-NO', { timeZone: 'Europe/Oslo' }) +
+        ', ' +
+        start.toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Oslo' }) +
+        ' - ' +
+        end.toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Oslo' })
+    );
+}
+
+export function formatRecords(records, fields) {
+    for (let record of records) {
+        formatRecord(record, fields);
+    }
+    return records;
+}
+
+export function formatRecord(record, fields) {
+    for (let field of fields) {
+        let fieldname = field.newName === undefined ? field.name : field.newName;
+        if (field.type == 'datetime') {
+            record[fieldname] = formatDatetime(record[field.name]);
+        } else if (field.type == 'date') {
+            record[fieldname] = formatDate(record[field.name]);
+        } else if (field.type == 'datetimeinterval') {
+            record[fieldname] = formatDatetimeinterval(record[field.start], record[field.end]);
+        }
+    }
+    return record;
+}

--- a/force-app/main/userCommunity/lwc/datetimeFormatterNorwegianTime/datetimeFormatterNorwegianTime.js-meta.xml
+++ b/force-app/main/userCommunity/lwc/datetimeFormatterNorwegianTime/datetimeFormatterNorwegianTime.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/userCommunity/lwc/mineBestillingerWrapper/mineBestillingerWrapper.js
+++ b/force-app/main/userCommunity/lwc/mineBestillingerWrapper/mineBestillingerWrapper.js
@@ -18,7 +18,7 @@ import WORKORDER_NOTIFY_DISPATCHER from '@salesforce/schema/WorkORder.HOT_IsNoti
 import WORKORDER_STATUS from '@salesforce/schema/WorkOrder.Status';
 import WORKORDER_ID from '@salesforce/schema/WorkOrder.Id';
 import { refreshApex } from '@salesforce/apex';
-import { formatRecord } from 'c/datetimeFormatter';
+import { formatRecord } from 'c/datetimeFormatterNorwegianTime';
 import { updateRecord } from 'lightning/uiRecordApi';
 
 export default class MineBestillingerWrapper extends NavigationMixin(LightningElement) {

--- a/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.js
+++ b/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.js
@@ -3,7 +3,7 @@ import { refreshApex } from '@salesforce/apex';
 import getMyWageClaims from '@salesforce/apex/HOT_WageClaimListController.getMyWageClaims';
 import { columns, mobileColumns } from './columns';
 import { NavigationMixin } from 'lightning/navigation';
-import { formatRecord } from 'c/datetimeFormatter';
+import { formatRecord } from 'c/datetimeFormatterNorwegianTime';
 import { defaultFilters, compare } from './filters';
 import HOT_informationModal from 'c/hot_informationModal';
 export default class Hot_wageClaimList extends NavigationMixin(LightningElement) {


### PR DESCRIPTION
Viser alltid norske tider for FRILANS på:
-Ledige oppdrag liste
-Påmeldte oppdrag liste
-Mine oppdrag liste
-Ledig på lønn liste
-Ønsket til oppdrag liste

- Oppdrag-start tidspunkt i "mine samtaler som frilans" meldingslister.
- Oppdragsdetaljer når man trykker gå til bestilling inne på en samtale.

Viser alltid norske tider for BRUKER på:
- Mine bestillinger

**NB!** Vises ikke norske tider i kalender for frilans, så den skjules når brukeren befinner seg utenfor norsk tiddsone