### PR TITLE
TOLK-3103 : Legge til validationrule som hindrer slettet events fra outlook sync blir opprettet på nytt

### DIFF
--- a/force-app/main/default/objects/Event/validationRules/HOT_Prevent_Faulty_Outlook_Events.validationRule-meta.xml
+++ b/force-app/main/default/objects/Event/validationRules/HOT_Prevent_Faulty_Outlook_Events.validationRule-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HOT_Prevent_Faulty_Outlook_Events</fullName>
+    <active>true</active>
+    <description>This should stop the insertion of deleted events being reinserted from outlook sync</description>
+    <errorConditionFormula>AND(
+  $RecordType.DeveloperName = &quot;HOT_Events&quot;,
+  BEGINS(Subject, &quot;SA-&quot;),
+  ISBLANK(WhatId),
+  CONTAINS(Description, &quot;Link til TinD: https://navdialog&quot;)
+)</errorConditionFormula>
+    <errorMessage>Event cannot be saved: Missing linked record (WhatId) for HOT Event with TinD link.</errorMessage>
+</ValidationRule>


### PR DESCRIPTION
skal hindre opprettelse av events som kommer fra outlook sync, men som egentlig allerede er slettet