### PR TITLE
TOLK-3512: Legg til fil formidler varsler: Juster status for varsel i Forespørsel og WO

### DIFF
--- a/force-app/main/facelift/lwc/hot_myRequestsWrapper/hot_myRequestsWrapper.js
+++ b/force-app/main/facelift/lwc/hot_myRequestsWrapper/hot_myRequestsWrapper.js
@@ -86,6 +86,13 @@ export default class Hot_myRequestsWrapper extends NavigationMixin(LightningElem
             .querySelectorAll('c-record-files-without-sharing')
             .forEach((cmp) => cmp.refreshContentDocuments());
 
+        const isRequestApproved = this.request?.Status__c === 'Godkjent';
+        const isWorkOrderInNotifiableState = ['New', 'Scheduled', 'Dispatched'].includes(this.workOrder?.Status);
+
+        if (!isRequestApproved || !isWorkOrderInNotifiableState) {
+            return;
+        }
+
         try {
             await notifyDispatchersFilesUploaded({
                 requestId: this.request?.Id ?? this.recordId,


### PR DESCRIPTION
Når bestiller legger til filer skal den aktuelle formidler få varsel når status er: 

- Forespørsel status: Godkjent && Arbeidsordre status skal være: Åpen/Under behandling/Tildelt