### PR TITLE
TOLK-3572 : Voiceover på nyheter til tolketjenesten sier feil antall nyheter

### DIFF
--- a/force-app/main/facelift/lwc/hot_announcementListViewer/hot_announcementListViewer.css
+++ b/force-app/main/facelift/lwc/hot_announcementListViewer/hot_announcementListViewer.css
@@ -62,6 +62,11 @@ dialog.modal-container .close-btn {
 }
 
 dialog.modal-container .close-btn:focus {
+    outline: none;
+    border-color: transparent;
+}
+
+dialog.modal-container .close-btn:focus-visible {
     border-color: #0067c5;
     outline: none;
 }
@@ -147,6 +152,7 @@ dialog.modal-container .close-btn:hover {
     -ms-user-select: none;
     user-select: none;
 }
+
 @media (max-width: 600px) {
     .navds-button {
         display: flex;
@@ -177,6 +183,20 @@ dialog.modal-container .close-btn:hover {
 }
 .news-button {
     position: relative;
+}
+
+.news-button:hover {
+    border-color: #0067c5;
+}
+
+.news-button:focus {
+    outline: none;
+    border-color: #f2f3f5;
+}
+
+.news-button:focus-visible {
+    outline: none;
+    border-color: #0067c5;
 }
 
 .news-badge {

--- a/force-app/main/facelift/lwc/hot_announcementListViewer/hot_announcementListViewer.html
+++ b/force-app/main/facelift/lwc/hot_announcementListViewer/hot_announcementListViewer.html
@@ -17,11 +17,7 @@
         </button>
 
         <!-- Modal -->
-        <dialog
-            class="modal-announcements modal-container"
-            aria-label="Nyhetssenter for tolketjenesten"
-            onclose={closeModal}
-        >
+        <dialog class="modal-announcements modal-container" aria-label={modalAriaLabel} onclose={closeModal}>
             <template lwc:if={isLoading}>
                 <div class="loader-container">
                     <c-hot_loader size="3xlarge"></c-hot_loader>

--- a/force-app/main/facelift/lwc/hot_announcementListViewer/hot_announcementListViewer.js
+++ b/force-app/main/facelift/lwc/hot_announcementListViewer/hot_announcementListViewer.js
@@ -21,6 +21,16 @@ export default class Hot_announcementListViewer extends LightningElement {
         return (this.unreadAnnouncementIds || []).length;
     }
 
+    get modalAriaLabel() {
+        const count = (this.announcements || []).length;
+
+        if (count === 1) {
+            return 'Nyheter fra Tolketjenesten, 1 nyhet';
+        }
+
+        return `Nyheter fra Tolketjenesten, ${count} nyheter`;
+    }
+
     async handleShowAnnouncements() {
         this.updateVisibleAnnouncements();
 
@@ -28,7 +38,6 @@ export default class Hot_announcementListViewer extends LightningElement {
 
         if (dialog) {
             dialog.showModal();
-            dialog.focus();
         }
 
         await this.setNewsRead();

--- a/force-app/main/facelift/lwc/hot_notificationListViewer/hot_notificationListViewer.css
+++ b/force-app/main/facelift/lwc/hot_notificationListViewer/hot_notificationListViewer.css
@@ -94,11 +94,12 @@ input[type='reset'] {
 
 .close-btn:focus {
     outline: none;
+    border-color: transparent;
 }
 
 .close-btn:focus-visible {
-    border-color: #0067c5;
     outline: none;
+    border-color: #0067c5;
 }
 
 .close-btn:hover {
@@ -209,8 +210,18 @@ input[type='reset'] {
     line-height: 1.3;
     margin: 0;
 }
-.navds-button:hover,
+
+.navds-button:hover {
+    border-color: #0067c5;
+}
+
 .navds-button:focus {
+    outline: none;
+    border-color: #f2f3f5;
+}
+
+.navds-button:focus-visible {
+    outline: none;
     border-color: #0067c5;
 }
 .navds-button {

--- a/force-app/main/facelift/lwc/hot_notificationListViewer/hot_notificationListViewer.html
+++ b/force-app/main/facelift/lwc/hot_notificationListViewer/hot_notificationListViewer.html
@@ -1,7 +1,7 @@
 <template>
     <div class="notification-center">
         <button
-            class="navds-button navds-body-short"
+            class="navds-button navds-body-short notification-button"
             onclick={toggleNotifications}
             aria-label="Vis varsler fra Tolketjenesten"
             aria-haspopup="dialog"

--- a/force-app/main/facelift/lwc/hot_notificationListViewer/hot_notificationListViewer.js
+++ b/force-app/main/facelift/lwc/hot_notificationListViewer/hot_notificationListViewer.js
@@ -156,11 +156,25 @@ export default class Hot_notificationListViewer extends NavigationMixin(Lightnin
     }
 
     toggleNotifications() {
+        const wasOpen = this.showNotifications;
+
         this.showNotifications = !this.showNotifications;
+
         if (this.showNotifications) {
             refreshApex(this.wiredNotificationResult);
+
             setTimeout(() => {
-                this.template.querySelector('.dropdown')?.focus();
+                const first = this._getTrapElements()[0];
+                first && first.focus();
+            });
+
+            return;
+        }
+
+        if (wasOpen) {
+            requestAnimationFrame(() => {
+                const notificationButton = this.template.querySelector('.notification-button');
+                notificationButton?.focus();
             });
         }
     }
@@ -168,6 +182,11 @@ export default class Hot_notificationListViewer extends NavigationMixin(Lightnin
     handleKeyDown(e) {
         if (e.key === 'Escape' || e.key === 'Esc') {
             this.showNotifications = false;
+
+            requestAnimationFrame(() => {
+                const notificationButton = this.template.querySelector('.notification-button');
+                notificationButton?.focus();
+            });
         }
         if (e.key !== 'Tab') return;
         const focusables = this._getTrapElements();


### PR DESCRIPTION
Løsning: 
- Nyheter til tolketjenesten skal lese opp antall nyheter nå. Årsaken til feilen er at ingen har lagt til at den skulle lese opp listen av nyheter. Så den leste kun dialog boksen, modal title og lukke knappen(3 objekter). 
- Jeg har også rettet opp hover outline fargen når nyhetene blir tastet med datamus, tastatur og voiceover. Oppdaterte user accessibility sånn at den følger dagens aksel standard. feks når noen trykker på knappen som var fokus på modal title, det er nå flyttet til lukke knappen. 

Varsel liste: 
- Har flyttet fokus til lukke knappen når noen klikker på knappen. Fikset hover outline fargen basert på tastetrykk datamus, tastatur og voiceover. 