### PR TITLE
Slette nyheter ett år etter opprettelsesdato

### DIFF
--- a/force-app/main/default/customMetadata/Deletion_Policy.HOT_DeleteNews.md-meta.xml
+++ b/force-app/main/default/customMetadata/Deletion_Policy.HOT_DeleteNews.md-meta.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>HOT_DeleteNews</label>
+    <protected>false</protected>
+    <values>
+        <field>Childs_to_Delete__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Delete_Childs__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Delete_Parents__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Delete_Related_Files__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Fields_to_Anonymize__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Parents_to_Delete__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Policy_Batch_Size__c</field>
+        <value xsi:type="xsd:double">200.0</value>
+    </values>
+    <values>
+        <field>Policy_Condition_Field__c</field>
+        <value xsi:type="xsd:string">HOT_DelPol_To_Delete_Record__c</value>
+    </values>
+    <values>
+        <field>Policy_Object__c</field>
+        <value xsi:type="xsd:string">HOT_Announcement__c</value>
+    </values>
+    <values>
+        <field>Policy_Success_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Policy_Type__c</field>
+        <value xsi:type="xsd:string">Record Deletion</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/objects/HOT_Announcement__c/fields/HOT_DelPol_To_Delete_Record__c.field-meta.xml
+++ b/force-app/main/default/objects/HOT_Announcement__c/fields/HOT_DelPol_To_Delete_Record__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HOT_DelPol_To_Delete_Record__c</fullName>
+    <formula>IF
+(TODAY() - DATEVALUE(CreatedDate) &gt; 365,
+true,
+false
+)</formula>
+    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+    <label>HOT DelPol To Delete Record</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>


### PR DESCRIPTION
- La til en Deletion policy (HOT_DeleteNews) som sletter en nyhet når det har gått ett år fra CreatedDate